### PR TITLE
Added pull command in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,22 +180,34 @@ For simplicity, the following commands will not include the `java -jar` part req
 
 ### Usage
 
+To use the tool on your app's Android Studio project, enter the root directory of your project from the command line.
+
+#### Help
+
 `transifex`, `transifex -h`, `transifex --help`
 Displays a help dialog with all the options and commands.
 
-`transifex -h <command>`
+`transifex help <command>`
 Get help for a particular command.
 
-To use the tool on your app, enter the root directory of your Android Studio project.
+#### Pushing
 
-`transifex -t <transifex_token> -s <transifex_secret> push -m <app_module_name>`
-Pushes the source strings of your app residing in a module named "app_module_name". The tool will get the `strings.xml` file found in the main source set of the specified module, process it and push it. 
+`transifex push -t <transifex_token> -s <transifex_secret> -m <app_module_name>`
+Pushes the source strings of your app found in a module named "app_module_name". The tool reads the `strings.xml` resource file found in the main source set of the specified module: `app_module_name/src/main/res/values/strings.xml`. It processes it and pushes the result to the Transifex CDS. 
 
-`transifex -t <transifex_token> -s <transifex_secret> push -f path/to/strings1.xml path2/to/strings2.xml`
-If your app has a more complex string setup, you can specify one or more string files.
+`transifex push -t <transifex_token> -s <transifex_secret> -f path/to/strings1.xml path2/to/strings2.xml`
+If your app has a more complex string setup, you can specify one or more string resource files.
 
-`transifex -t <transifex_token> -s <transifex_secret> clear`
+`transifex clear -t <transifex_token> -s <transifex_secret>`
 Clears all existing resource content from CDS. This action will also remove existing localizations.
+
+#### Pulling
+
+`transifex pull -t <transifex_token> -m <app_module_name> -l <locale>...`
+Downloads the translations from Transifex CDS for the specified locales and stores them in txstrings.json files under the "assets" directory of the main source set of the specified app module: `app_module_name/src/main/assets/txnative`. The directory is created if needed. These files will be bundled inside your app and accessed by TxNative.
+
+`transifex pull -t <transifex_token> -d <directory>`
+If you have a different set-up, you can enter the path to your app's `assets` directory.
 
 ## License
 Licensed under Apache License 2.0, see [LICENSE](LICENSE) file.

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
@@ -2,12 +2,16 @@ package com.transifex.clitool;
 
 import com.google.gson.Gson;
 import com.transifex.common.LocaleData;
+import com.transifex.common.Utils;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import androidx.annotation.NonNull;
 import okhttp3.mockwebserver.Dispatcher;
@@ -21,11 +25,16 @@ public class MainClassTest {
 
     private MockWebServer server = null;
     private String baseUrl = null;
+    File tempDir = new File("build" + File.separator + "unitTestTempDir");
 
     @Before
     public void setUp() {
         server = new MockWebServer();
         baseUrl = server.url("").toString();
+
+        if (tempDir.exists()) {
+            Utils.deleteDirectory(tempDir);
+        }
     }
 
     @After
@@ -35,9 +44,57 @@ public class MainClassTest {
                 server.shutdown();
             } catch (IOException ignored) {}
         }
+
+        if (tempDir.exists()) {
+            boolean deleted = Utils.deleteDirectory(tempDir);
+            if (!deleted) {
+                System.out.println("Could not delete tmp dir after test. Next test may fail.");
+            }
+        }
     }
 
-    private Dispatcher getPostDispatcher() {
+    public static final String elBody = "{\"data\":{\"test_key\":{\"string\":\"Καλημέρα\"},\"another_key\":{\"string\":\"Καλό απόγευμα\"},\"key3\":{\"string\":\"\"}}}";
+    public static final String esBody = "{\"data\":{\"test_key\":{\"string\":\"Buenos días\"},\"another_key\":{\"string\":\"Buenas tardes\"},\"key3\":{\"string\":\"\"}}}";
+
+    public static Dispatcher getElEsDispatcher() {
+        Dispatcher dispatcher = new Dispatcher() {
+
+            @NonNull
+            @Override
+            public MockResponse dispatch (RecordedRequest request) throws InterruptedException {
+
+                switch (request.getPath()) {
+                    case "/content/el":
+                        return new MockResponse().setResponseCode(200).setBody(elBody);
+                    case "/content/es":
+                        return new MockResponse().setResponseCode(200).setBody(esBody);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+
+        return dispatcher;
+    }
+
+    public static Dispatcher getElDispatcher() {
+        Dispatcher dispatcher = new Dispatcher() {
+
+            @NonNull
+            @Override
+            public MockResponse dispatch (RecordedRequest request) throws InterruptedException {
+
+                switch (request.getPath()) {
+                    case "/content/el":
+                        return new MockResponse().setResponseCode(200).setBody(elBody);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+
+        return dispatcher;
+    }
+
+    public static Dispatcher getPostDispatcher() {
         Dispatcher dispatcher = new Dispatcher() {
 
             @NonNull
@@ -67,7 +124,7 @@ public class MainClassTest {
 
     @Test
     public void testPush_noSecret() {
-        String args = "-t token push -m app";
+        String args = "push -t token -m app";
         int returnValue = MainClass.testMain(args);
 
         assertThat(returnValue).isEqualTo(2);
@@ -75,12 +132,11 @@ public class MainClassTest {
 
     @Test
     public void testPush_wrongModuleName() {
-        String args = "-t token -s secret push -m app2";
+        String args = "push -t token -s secret -m app2";
         int returnValue = MainClass.testMain(args);
 
         assertThat(returnValue).isEqualTo(1);
     }
-
 
     @Test
     public void testPush_useFile() {
@@ -89,7 +145,7 @@ public class MainClassTest {
 
         server.setDispatcher(getPostDispatcher());
 
-        String args = String.format("-t token -s secret -u %s push -f %s", baseUrl,
+        String args = String.format("-u %s push -t token -s secret -f %s", baseUrl,
                 "../txsdk/src/test/res/values/strings.xml");
         int returnValue = MainClass.testMain(args);
 
@@ -117,7 +173,7 @@ public class MainClassTest {
 
         server.setDispatcher(getPostDispatcher());
 
-        String args = String.format("-t token -s secret -u %s push -f %s -f %s", baseUrl,
+        String args = String.format("-u %s push -t token -s secret -f %s -f %s", baseUrl,
                 "../txsdk/src/test/res/values/strings.xml",
                 "../txsdk/src/test/res/values-el/strings.xml");
         int returnValue = MainClass.testMain(args);
@@ -142,7 +198,7 @@ public class MainClassTest {
     public void testClear() {
         server.setDispatcher(getPostDispatcher());
 
-        String args = String.format("-t token -s secret -u %s clear", baseUrl);
+        String args = String.format("-u %s clear -t token -s secret", baseUrl);
         int returnValue = MainClass.testMain(args);
 
         assertThat(returnValue).isEqualTo(0);
@@ -159,5 +215,83 @@ public class MainClassTest {
         LocaleData.TxPostData parsedPostData = gson.fromJson(postBody, LocaleData.TxPostData.class);
         assertThat(parsedPostData.meta.purge).isTrue();
         assertThat(parsedPostData.data).isEmpty();
+    }
+
+    @Test
+    public void testPull_normal() {
+        server.setDispatcher(getElEsDispatcher());
+
+        String args = String.format("-u %s pull -t token -l el es -d %s", baseUrl, tempDir.getPath());
+        int returnValue = MainClass.testMain(args);
+
+        assertThat(returnValue).isEqualTo(0);
+
+        File elFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "el", MainClass.OUT_FILE_NAME).toFile();
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(elFile));
+        } catch (IOException ignored) {}
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(elBody);
+
+        File esFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "es", MainClass.OUT_FILE_NAME).toFile();
+        String esString = null;
+        try {
+            esString = Utils.readInputStream(new FileInputStream(esFile));
+        } catch (IOException ignored) {}
+        assertThat(esString).isNotNull();
+        assertThat(esString).isEqualTo(esBody);
+    }
+
+    @Test
+    public void testPull_consecutiveRuns() {
+        server.setDispatcher(getElEsDispatcher());
+
+        String args = String.format("-u %s pull -t token -l el -d %s", baseUrl, tempDir.getPath());
+        int returnValue = MainClass.testMain(args);
+
+        assertThat(returnValue).isEqualTo(0);
+
+        args = String.format("-u %s pull -t token -l es -d %s", baseUrl, tempDir.getPath());
+        returnValue = MainClass.testMain(args);
+
+        assertThat(returnValue).isEqualTo(0);
+
+        File elFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "el", MainClass.OUT_FILE_NAME).toFile();
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(elFile));
+        } catch (IOException ignored) {}
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(elBody);
+
+        File esFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "es", MainClass.OUT_FILE_NAME).toFile();
+        String esString = null;
+        try {
+            esString = Utils.readInputStream(new FileInputStream(esFile));
+        } catch (IOException ignored) {}
+        assertThat(esString).isNotNull();
+        assertThat(esString).isEqualTo(esBody);
+    }
+
+    @Test
+    public void testPull_onlyElInResponse() {
+        server.setDispatcher(getElDispatcher());
+
+        String args = String.format("-u %s pull -t token -l el es -d %s", baseUrl, tempDir.getPath());
+        int returnValue = MainClass.testMain(args);
+
+        assertThat(returnValue).isEqualTo(1);
+
+        File elFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "el", MainClass.OUT_FILE_NAME).toFile();
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(elFile));
+        } catch (IOException ignored) {}
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(elBody);
+
+        File esFile = Paths.get(tempDir.getPath(), MainClass.OUT_DIR_NAME, "es", MainClass.OUT_FILE_NAME).toFile();
+        assertThat(esFile.exists()).isFalse();
     }
 }

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationsDownloader.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationsDownloader.java
@@ -1,0 +1,121 @@
+package com.transifex.common;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A class that makes use of {@link CDSHandler} to fetch translations from the CDS and save them
+ * to files.
+ */
+public class TranslationsDownloader {
+
+    private static final String TAG = CDSHandler.class.getSimpleName();
+    private static final Logger LOGGER = Logger.getLogger(TAG);
+
+    private final CDSHandler mCDSHandler;
+
+    public TranslationsDownloader(@NonNull CDSHandler cdsHandler) {
+        mCDSHandler = cdsHandler;
+    }
+
+    /**
+     * An {@link CDSHandler.FetchCallback} implementation that writes the provided input streams
+     * to files.
+     * <p>
+     * Each downloaded file is added on the <code>filesMap</code> using the respective locale code
+     * as key.
+     */
+    private static class DownloadTranslationsCallback implements CDSHandler.FetchCallback {
+
+        File directory;
+        String filename;
+
+        HashMap<String, File> filesMap = new HashMap<>(0);
+
+        public DownloadTranslationsCallback(@NonNull File directory, @NonNull String filename) {
+            this.directory = directory;
+            this.filename = filename;
+        }
+
+        @Override
+        public void onFetchingTranslations(@NonNull String[] localeCodes) {
+            filesMap = new HashMap<>(localeCodes.length);
+        }
+
+        @Override
+        public void onTranslationFetched(@Nullable InputStream inputStream, @NonNull String localeCode, @Nullable Exception exception) {
+            if (inputStream == null) {
+                return;
+            }
+
+            File localeDir = new File(directory.getAbsolutePath() + File.separator + localeCode);
+            localeDir.mkdirs();
+
+            File localeFile = new File(localeDir.getAbsolutePath() + File.separator + filename);
+            try {
+                FileOutputStream fileOutputStream = new FileOutputStream(localeFile, false);
+
+                FileChannel fileChannel = fileOutputStream.getChannel();
+                ReadableByteChannel readableByteChannel = Channels.newChannel(inputStream);
+                fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+                readableByteChannel.close();
+                fileChannel.close();
+
+                filesMap.put(localeCode, localeFile);
+            } catch (FileNotFoundException e) {
+                LOGGER.log(Level.SEVERE, "Error writing file " + localeFile.getAbsolutePath());
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "IOException when reading response for locale " + localeCode + " : " + e);
+            }
+        }
+
+        @Override
+        public void onFailure(@NonNull Exception exception) {}
+    }
+
+    /**
+     * Fetches translations from CDS and saves them to files.
+     * <p>
+     * For each locale, a subdirectory under the provided directory is created and a file containing
+     * the translations is created. Note that the provided directory should already exist. If a
+     * translation file already exists, it's overwritten.
+     *
+     * @param localeCode An optional locale to fetch translations from; if  set to <code>null</code>,
+     *                   it will fetch translations for the locale codes provided in the constructor.
+     * @param directory  The directory on which to save the translations. The directory should
+     *                   already exist.
+     * @param filename   The name of the translation file for a locale.
+     *
+     * @return A key-value map where each locale code points to the downloaded file containing the
+     * translations. If an error occurs, some or all locale codes will be missing from the map.
+     */
+    @NonNull
+    public HashMap<String, File> downloadTranslations(@Nullable String localeCode, @NonNull File directory,
+                                                      @NonNull String filename) {
+        if (!directory.isDirectory()) {
+            LOGGER.log(Level.SEVERE, "The provided directory does not exist: " + directory.getAbsolutePath());
+            return new HashMap<>(0);
+        }
+        if (filename == null || filename.isEmpty()) {
+            LOGGER.log(Level.SEVERE, "The provided filename is not correct: " + filename);
+            return new HashMap<>(0);
+        }
+
+        DownloadTranslationsCallback callback = new DownloadTranslationsCallback(directory, filename);
+        mCDSHandler.fetchTranslations(localeCode, callback);
+
+        return  callback.filesMap;
+    }
+}

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
@@ -1,6 +1,7 @@
 package com.transifex.common;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -11,8 +12,6 @@ public class Utils {
 
     /**
      * Reads an input stream to a string.
-     * <p>
-     * The caller should close the input stream.
      */
     public @NonNull static String readInputStream(@NonNull InputStream inputStream) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
@@ -22,6 +21,25 @@ public class Utils {
             result.append(line);
         }
 
+        reader.close();
+
         return result.toString();
+    }
+
+
+    /**
+     * Deletes a directory including its contents
+     *
+     * @return <code>true</code> if and only if the file or directory is successfully deleted;
+     * <code>false</code> otherwise
+     */
+    public static boolean deleteDirectory(File directoryToBeDeleted) {
+        File[] allContents = directoryToBeDeleted.listFiles();
+        if (allContents != null) {
+            for (File file : allContents) {
+                deleteDirectory(file);
+            }
+        }
+        return directoryToBeDeleted.delete();
     }
 }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/TranslationsDownloaderTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/TranslationsDownloaderTest.java
@@ -1,0 +1,220 @@
+package com.transifex.common;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TranslationsDownloaderTest {
+
+    private MockWebServer server = null;
+    private String baseUrl = null;
+    File tempDir = new File("build" + File.separator + "unitTestTempDir");
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+        baseUrl = server.url("").toString();
+
+        if (tempDir.exists()) {
+            Utils.deleteDirectory(tempDir);
+        }
+    }
+
+    @After
+    public void Teardown() {
+        if (server != null) {
+            try {
+                server.shutdown();
+            } catch (IOException ignored) {}
+        }
+
+        if (tempDir.exists()) {
+            boolean deleted = Utils.deleteDirectory(tempDir);
+            if (!deleted) {
+                System.out.println("Could not delete tmp dir after test. Next test may fail.");
+            }
+        }
+    }
+
+    @Test
+    public void testSaveTranslations_dirDoesNotExist() {
+        String[] localeCodes = new String[]{"el", "es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles).isEmpty();
+    }
+
+    @Test
+    public void testSaveTranslations_normalResponse() {
+        server.setDispatcher(CDSHandlerTest.getElEsDispatcher());
+
+        boolean tempDirCreated =  tempDir.mkdirs();
+        assertThat(tempDirCreated).isTrue();
+
+        String[] localeCodes = new String[]{"el", "es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+
+        RecordedRequest recordedRequest = null;
+        try {
+            recordedRequest = server.takeRequest();
+        } catch (InterruptedException ignored) {
+        }
+        assertThat(recordedRequest).isNotNull();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
+        assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json; charset=utf-8");
+
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles.keySet()).containsExactly("el", "es");
+        assertThat(translationFiles.get("el").getName()).isEqualTo("strings.txt");
+        assertThat(translationFiles.get("es").getName()).isEqualTo("strings.txt");
+
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(translationFiles.get("el")));
+        } catch (IOException ignored) {}
+
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+
+        String esString = null;
+        try {
+            esString = Utils.readInputStream(new FileInputStream(translationFiles.get("es")));
+        } catch (IOException ignored) {}
+
+        assertThat(esString).isNotNull();
+        assertThat(esString).isEqualTo(CDSHandlerTest.esBody);
+    }
+
+    @Test
+    public void testSaveTranslations_onlyElInResponse() {
+        server.setDispatcher(CDSHandlerTest.getElDispatcher());
+
+        boolean tempDirCreated =  tempDir.mkdirs();
+        assertThat(tempDirCreated).isTrue();
+
+        String[] localeCodes = new String[]{"el", "es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles.keySet()).containsExactly("el");
+
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(translationFiles.get("el")));
+        } catch (IOException ignored) {}
+
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+    }
+
+    @Test
+    public void testSaveTranslations_specifyLocale_normalResponse() {
+        server.setDispatcher(CDSHandlerTest.getElEsDispatcher());
+
+        boolean tempDirCreated =  tempDir.mkdirs();
+        assertThat(tempDirCreated).isTrue();
+
+        String[] localeCodes = new String[]{"el", "es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations("el", tempDir, "strings.txt");
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles.keySet()).containsExactly("el");
+
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(translationFiles.get("el")));
+        } catch (IOException ignored) {}
+
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+    }
+
+    @Test
+    public void testSaveTranslations_overwriteExistingFile() {
+        server.setDispatcher(CDSHandlerTest.getElDispatcher());
+
+        File localeDir = new File(tempDir.getAbsoluteFile() + File.separator + "el");
+        boolean localeDirCreated =  localeDir.mkdirs();
+        assertThat(localeDirCreated).isTrue();
+
+        File dummyElStringFile = new File(localeDir + File.separator + "strings.txt");
+        try {
+            FileOutputStream outputStream = new FileOutputStream(dummyElStringFile);
+            String dummyContent = "some text";
+            outputStream.write(dummyContent.getBytes(StandardCharsets.UTF_8));
+            outputStream.close();
+        } catch (IOException ignored) {}
+
+        String[] localeCodes = new String[]{"el"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles.keySet()).containsExactly("el");
+
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(translationFiles.get("el")));
+        } catch (IOException ignored) {}
+
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+    }
+
+    @Test
+    public void testSaveTranslations_skipExistingFileIfError() {
+        server.setDispatcher(CDSHandlerTest.getElDispatcher());
+
+        File localeDir = new File(tempDir.getAbsoluteFile() + File.separator + "es");
+        boolean localeDirCreated =  localeDir.mkdirs();
+        assertThat(localeDirCreated).isTrue();
+
+        File dummyEsStringFile = new File(localeDir + File.separator + "strings.txt");
+        String dummyContent = "some text";
+        try {
+            FileOutputStream outputStream = new FileOutputStream(dummyEsStringFile);
+            outputStream.write(dummyContent.getBytes(StandardCharsets.UTF_8));
+            outputStream.close();
+        } catch (IOException ignored) {}
+
+        String[] localeCodes = new String[]{"es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        assertThat(translationFiles).isEmpty();
+
+        String esString = null;
+        try {
+            esString = Utils.readInputStream(new FileInputStream(dummyEsStringFile));
+        } catch (IOException ignored) {}
+
+        assertThat(esString).isNotNull();
+        assertThat(esString).isEqualTo(dummyContent);
+    }
+}


### PR DESCRIPTION
CDSHandler has a low-level fetch method that
allows the caller to acces the translation input stream
from the server. The existing fetch method uses it under the hood.

TranslationsDownloader makes use of the new fetch method to
save the translations as files in the specified directory.

Added pull command in cli.

Moved token and secret option inside the subcommands.

Updated the cli section of the readme.

Added unit tests.