### PR TITLE
Full cache implementation

### DIFF
--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -2,6 +2,7 @@ package com.transifex.clitool;
 
 import com.transifex.common.CDSHandler;
 import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
 import com.transifex.common.TranslationsDownloader;
 
 import java.io.File;
@@ -42,8 +43,8 @@ public class MainClass {
     private static final String TAG = MainClass.class.getSimpleName();
     private static final Logger LOGGER = Logger.getLogger(TAG);
 
-    static final String OUT_DIR_NAME = "txnative";
-    static final String OUT_FILE_NAME = "txstrings.json";
+    static final String OUT_DIR_NAME = TranslationMapStorage.DEFAULT_TRANSLATIONS_DIR_NAME;
+    static final String OUT_FILE_NAME = TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME;
 
     @Mixin
     private ReusableAttributes reusable;

--- a/TransifexNativeSDK/common/build.gradle
+++ b/TransifexNativeSDK/common/build.gradle
@@ -23,4 +23,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    testImplementation 'commons-io:commons-io:2.6'
 }

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
@@ -42,4 +42,22 @@ public class Utils {
         }
         return directoryToBeDeleted.delete();
     }
+
+    /**
+     * Deletes the directory's contents
+     *
+     * @return <code>true</code> if it's a directory and it's content is successfully deleted or
+     * it's already empty; <code>false</code> otherwise
+     */
+    public static boolean deleteDirectoryContents(File directoryToBeDeleted) {
+        File[] allContents = directoryToBeDeleted.listFiles();
+        boolean success = false;
+        if (allContents != null) {
+            success = true;
+            for (File file : allContents) {
+                success &= deleteDirectory(file);
+            }
+        }
+        return  success;
+    }
 }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
@@ -78,6 +78,55 @@ public class LocaleDataTest {
     }
 
     @Test
+    public void testLocaleStringsGetMap() {
+        LocaleData.LocaleStrings a = getElLocaleStrings();
+
+        HashMap<String, LocaleData.StringInfo> map = a.getMap();
+
+        assertThat(a.get("test_key")).isEqualTo("Καλημέρα");
+        assertThat(a.get("test_key3")).isEqualTo("");
+    }
+
+    @Test
+    public void testLocaleStringsGetMap_alterMap() {
+        LocaleData.LocaleStrings a = getElLocaleStrings();
+
+        HashMap<String, LocaleData.StringInfo> map = a.getMap();
+        map.put("test_key4", new LocaleData.StringInfo("some text"));
+
+        assertThat(a.get("test_key4")).isEqualTo("some text");
+    }
+
+    @Test
+    public void testLocaleStringsPutGet() {
+        LocaleData.LocaleStrings a = new LocaleData.LocaleStrings(10);
+        a.put("test_key", new LocaleData.StringInfo("some text"));
+
+        assertThat(a.get("test_key")).isEqualTo("some text");
+    }
+
+    @Test
+    public void testLocaleStringsCopyConstructor() {
+        LocaleData.LocaleStrings a = getElLocaleStrings();
+        LocaleData.LocaleStrings sameAsA = getElLocaleStrings();
+
+        LocaleData.LocaleStrings copyOfA = new LocaleData.LocaleStrings(a);
+        a.put("test_key4", new LocaleData.StringInfo("some text"));
+
+        assertThat(copyOfA).isNotEqualTo(a);
+        assertThat(copyOfA).isEqualTo(sameAsA);
+    }
+
+    @Test
+    public void testTranslationMapPutGet() {
+        LocaleData.TranslationMap a = new LocaleData.TranslationMap(10);
+        a.put("el", getElLocaleStrings());
+
+        assertThat(a.getLocales()).containsExactly("el");
+        assertThat(a.get("el")).isEqualTo(getElLocaleStrings());
+    }
+
+    @Test
     public void testTranslationMapHash() {
         LocaleData.TranslationMap a = getElEsTranslationMap();
         LocaleData.TranslationMap a2 = getElEsTranslationMap();
@@ -94,4 +143,17 @@ public class LocaleDataTest {
         assertThat(a).isEqualTo(a2);
         assertThat(a).isNotEqualTo(b);
     }
+
+    @Test
+    public void testTranslationMapCopyConstructor() {
+        LocaleData.TranslationMap a = getElEsTranslationMap();
+        LocaleData.TranslationMap sameAsA = getElEsTranslationMap();
+
+        LocaleData.TranslationMap copyOfA = new LocaleData.TranslationMap(a);
+        a.put("de", getElLocaleStrings());
+
+        assertThat(copyOfA).isNotEqualTo(a);
+        assertThat(copyOfA).isEqualTo(sameAsA);
+    }
+
 }

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.4'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    testImplementation 'org.mockito:mockito-core:3.8.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/TransifexNativeSDK/txsdk/src/androidTest/assets/txnative/el/txstrings.json
+++ b/TransifexNativeSDK/txsdk/src/androidTest/assets/txnative/el/txstrings.json
@@ -1,0 +1,1 @@
+{"data":{"test_key":{"string":"Καλημέρα"},"another_key":{"string":"Καλό απόγευμα"},"key3":{"string":""}}}

--- a/TransifexNativeSDK/txsdk/src/androidTest/assets/txnative/es/txstrings.json
+++ b/TransifexNativeSDK/txsdk/src/androidTest/assets/txnative/es/txstrings.json
@@ -1,0 +1,1 @@
+{"data":{"test_key":{"string":"Buenos días"},"another_key":{"string":"Buenas tardes"},"key3":{"string":""}}}

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/TranslationMapStorageAndroidAssetsTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/TranslationMapStorageAndroidAssetsTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 @SmallTest
 public class TranslationMapStorageAndroidAssetsTest {
 
-    // The tests rely on have the following directories:
+    // The tests rely on the following directories:
     //
     // androidTest/assets/test_normal
     // androidTest/assets/test_oneLocaleHasInvalidJson
@@ -39,23 +39,19 @@ public class TranslationMapStorageAndroidAssetsTest {
     }
 
     @Test
-    public void testFromAssetsDirectory_dirDoesNotExist_returnEmptyTranslationMap() {
+    public void testFromAssetsDirectory_dirDoesNotExist_returnNullTranslationMap() {
         TranslationMapStorageAndroid reader = new TranslationMapStorageAndroid(assetManager, "strings.txt");
         LocaleData.TranslationMap map = reader.fromAssetsDirectory("wrongDir");
 
-        // The behavior is different to TranslationMapStorage because the underlying AssetFile
-        // always returns true for "isDir()"
-        assertThat(map).isNotNull();
-        assertThat(map.getLocales()).isEmpty();
+        assertThat(map).isNull();
     }
 
     @Test
-    public void testFromAssetsDirectory_haveFileWhereLocaleDirExpected_returnEmptyTranslationMap() {
+    public void testFromAssetsDirectory_haveFileWhereLocaleDirExpected_returnNullTranslationMap() {
         TranslationMapStorageAndroid reader = new TranslationMapStorageAndroid(assetManager, "strings.txt");
         LocaleData.TranslationMap map = reader.fromAssetsDirectory("test_fileInsteadLocaleDir");
 
-        assertThat(map).isNotNull();
-        assertThat(map.getLocales()).isEmpty();
+        assertThat(map).isNull();
     }
 
     @Test

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/TranslationMapStorageFilesTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/TranslationMapStorageFilesTest.java
@@ -31,7 +31,7 @@ public class TranslationMapStorageFilesTest {
     public void setUp() {
         appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         File filesDir = appContext.getFilesDir();
-        tempDir = new File(filesDir.getPath() + "unitTestTempDir");
+        tempDir = new File(filesDir.getPath() + File.separator + "unitTestTempDir");
         if (tempDir.exists()) {
             com.transifex.common.Utils.deleteDirectory(tempDir);
         }

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxDiskTranslationsProviderTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxDiskTranslationsProviderTest.java
@@ -1,0 +1,50 @@
+package com.transifex.txnative.cache;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+import com.transifex.common.LocaleData;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TxDiskTranslationsProviderTest {
+
+    // This test, in contrast to the unit test found in the "test" folder, tests the AssetManager
+    // version of TxDiskTranslationsProvider.
+
+    // The tests rely on the following directory:
+    //
+    // androidTest/assets/txnative
+    //
+    // Note that aapt2 will remove empty directories when packing the assets. So there is no reason
+    // to test for an empty directory.
+
+    Context appContext = null;
+    AssetManager assetManager;
+
+    @Before
+    public void setUp() {
+        appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        assetManager = appContext.getAssets();
+    }
+
+    @Test
+    public void testGetTranslations_translationsInAssets() {
+        TxDiskTranslationsProvider provider = new TxDiskTranslationsProvider(assetManager, "txnative");
+        LocaleData.TranslationMap map = provider.getTranslations();
+
+        assertThat(map).isEqualTo(TxStandardCacheTest.getAssetsEquivalentTranslationMap());
+    }
+
+    @Test
+    public void testGetTranslations_dirDoesNotExist_returnNullTranslationMap() {
+        TxDiskTranslationsProvider provider = new TxDiskTranslationsProvider(assetManager, "wrongDir");
+
+        assertThat(provider.getTranslations()).isNull();
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxStandardCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxStandardCacheTest.java
@@ -1,0 +1,179 @@
+package com.transifex.txnative.cache;
+
+import android.content.Context;
+
+import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
+import com.transifex.common.Utils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import androidx.test.espresso.core.internal.deps.guava.util.concurrent.MoreExecutors;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TxStandardCacheTest {
+
+    // The tests rely on the following directory:
+    //
+    // androidTest/assets/txnative
+
+    Context appContext = null;
+    File txNativeCacheDir;
+
+    @Before
+    public void setUp() {
+        appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        File cacheDir = appContext.getCacheDir();
+        txNativeCacheDir= new File(cacheDir.getPath() +File.separator + TranslationMapStorage.DEFAULT_TRANSLATIONS_DIR_NAME);
+        if (txNativeCacheDir.exists()) {
+            Utils.deleteDirectory(txNativeCacheDir);
+        }
+    }
+
+    @After
+    public void Teardown() {
+        if (txNativeCacheDir.exists()) {
+            boolean deleted = Utils.deleteDirectory(txNativeCacheDir);
+            if (!deleted) {
+                System.out.println("Could not delete tmp dir after test. Next test may fail.");
+            }
+        }
+    }
+
+    // This map is identical to the serialized version stored at: androidTest/assets/txnative
+    // and accessed at runtime in the app's Assets folder
+    protected static LocaleData.TranslationMap getAssetsEquivalentTranslationMap() {
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(2);
+
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(4);
+        elStrings.put("test_key", new LocaleData.StringInfo("Καλημέρα"));
+        elStrings.put("another_key", new LocaleData.StringInfo("Καλό απόγευμα"));
+        elStrings.put("key3", new LocaleData.StringInfo(""));
+        map.put("el", elStrings);
+
+        LocaleData.LocaleStrings esStrings = new LocaleData.LocaleStrings(4);
+        esStrings.put("test_key", new LocaleData.StringInfo("Buenos días"));
+        esStrings.put("another_key", new LocaleData.StringInfo("Buenas tardes"));
+        esStrings.put("key3", new LocaleData.StringInfo(""));
+        map.put("es", esStrings);
+
+        return map;
+    }
+
+    // This map represents translation that could be coming from an updated source such as CDS.
+    // It actually contains one locale less than the original.
+    private static LocaleData.TranslationMap getUpdatedTranslationMap() {
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(2);
+
+        LocaleData.LocaleStrings esStrings = new LocaleData.LocaleStrings(4);
+        esStrings.put("test_key", new LocaleData.StringInfo("Buenos días 2"));
+        esStrings.put("another_key", new LocaleData.StringInfo("Buenas tardes"));
+        esStrings.put("key3", new LocaleData.StringInfo("Buenas noches"));
+        map.put("es", esStrings);
+
+        return map;
+    }
+
+    // This is the expected result of applying getUpdatedTranslationMap() on getAssetsEquivalentTranslationMap() using
+    // TxUpdateFilterCache.UPDATE_USING_TRANSLATED
+    private LocaleData.TranslationMap getTranslationsForUpdateUsingTranslatedGroundTruth() {
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(2);
+
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(4);
+        elStrings.put("test_key", new LocaleData.StringInfo("Καλημέρα"));
+        elStrings.put("another_key", new LocaleData.StringInfo("Καλό απόγευμα"));
+        map.put("el", elStrings);
+
+        LocaleData.LocaleStrings esStrings = new LocaleData.LocaleStrings(4);
+        esStrings.put("test_key", new LocaleData.StringInfo("Buenos días 2"));
+        esStrings.put("another_key", new LocaleData.StringInfo("Buenas tardes"));
+        esStrings.put("key3", new LocaleData.StringInfo("Buenas noches"));
+        map.put("es", esStrings);
+
+        return map;
+    }
+
+    // Make internal executor run in same thread using reflection. If the TxStandardCache
+    // implementation changes, we have to update the reflection.
+    private boolean changeToSameThreadExecutor(TxCache cache) {
+        boolean reflectionSuccess = false;
+        try {
+            Field executorField = cache.getClass().getDeclaredField("mExecutor");
+            executorField.setAccessible(true);
+            executorField.set(cache, MoreExecutors.directExecutor());
+            reflectionSuccess = true;
+        } catch (NoSuchFieldException ignored) {
+        } catch (IllegalAccessException ignored) {
+        }
+
+        return reflectionSuccess;
+    }
+
+    @Test
+    // Make sure that we read the translations bundled in the app's Assets correctly
+    public void testGetCache_translationsInAssets() {
+        TxCache cache = TxStandardCache.getCache(appContext, null, null);
+        assertThat(cache.get()).isEqualTo(getAssetsEquivalentTranslationMap());
+    }
+
+    @Test
+    // Make sure that an update does not change the returned translations and that the updated
+    // translations are saved on the app's cache directory
+    public void testUpdate_translationsInAssets_returnSameMapAndSaveUpdatedMapOnDisk() {
+        TxCache cache = TxStandardCache.getCache(appContext, null, null);
+        assertThat(changeToSameThreadExecutor(cache)).isTrue();
+
+        cache.update(getUpdatedTranslationMap());
+
+        // Returned map should remain the same as the one originally loaded from assets
+        assertThat(cache.get()).isEqualTo(getAssetsEquivalentTranslationMap());
+
+        // Make sure the updated translations map is written in the expected cache directory
+        File cachedTranslationsDir = new File(appContext.getCacheDir() + File.separator + TranslationMapStorage.DEFAULT_TRANSLATIONS_DIR_NAME);
+        TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        assertThat(storage.fromDisk(cachedTranslationsDir)).isEqualTo(getUpdatedTranslationMap());
+    }
+
+    @Test
+    // Make sure that a new cache instance sees the translations in the app's cache directory saved
+    // from an update to a previous cache instance
+    public void testUpdateAndNewCacheGet_translationsInAssets_returnUpdatedMapFromDisk() {
+        // Make a cache that saves the updated translations on disk
+        TxCache cache = TxStandardCache.getCache(appContext, null, null);
+        assertThat(changeToSameThreadExecutor(cache)).isTrue();
+
+        cache.update(getUpdatedTranslationMap());
+
+        // Make another cache after having the translations saved on disk by the previous cache
+        TxCache secondRunCache = TxStandardCache.getCache(appContext, null, null);
+        assertThat(changeToSameThreadExecutor(secondRunCache)).isTrue();
+
+        assertThat(secondRunCache.get()).isEqualTo(getUpdatedTranslationMap());
+    }
+
+    @Test
+    // Make sure that a new cache instance sees the translations in the app's cache directory saved
+    // from an update to a previous cache instance
+    public void testUpdateAndNewCacheGet_translationsInAssetsAndUpdateUsingTranslatedPolicy_returnUpdatedMapFromDisk() {
+        // Make a cache that saves the updated translations on disk. The update polocy used here,
+        // doesn't matter
+        TxCache cache = TxStandardCache.getCache(appContext, null, null);
+        assertThat(changeToSameThreadExecutor(cache)).isTrue();
+
+        cache.update(getUpdatedTranslationMap());
+
+        // Make another cache after having the translations saved on disk by the previous cache
+        TxCache secondRunCache = TxStandardCache.getCache(appContext, TxUpdateFilterCache.UPDATE_USING_TRANSLATED, null);
+        assertThat(changeToSameThreadExecutor(secondRunCache)).isTrue();
+
+        assertThat(secondRunCache.get()).isEqualTo(getTranslationsForUpdateUsingTranslatedGroundTruth());
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
@@ -1,11 +1,12 @@
 package com.transifex.txnative;
 
-import android.os.AsyncTask;
 import android.util.Log;
 
 import com.transifex.common.CDSHandler;
 import com.transifex.common.LocaleData;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 
 import androidx.annotation.NonNull;
@@ -21,8 +22,10 @@ public class CDSHandlerAndroid extends CDSHandler {
 
     private static final String TAG = CDSHandler.class.getSimpleName();
 
+    private final Executor mExecutor;
+
     /**
-     * A callback that provides the results of {@link #fetchTranslationsAsync(String, FetchTranslationsCallback)} (String, FetchTranslationsCallback)}
+     * A callback that provides the results of {@link #fetchTranslationsAsync(String, FetchTranslationsCallback)}
      * when the operation is complete.
      */
     interface FetchTranslationsCallback {
@@ -50,6 +53,7 @@ public class CDSHandlerAndroid extends CDSHandler {
      */
     public CDSHandlerAndroid(@Nullable String[] localeCodes, @NonNull String token, @Nullable String secret, @NonNull String csdHost) {
         super(localeCodes, token, secret, csdHost);
+        mExecutor = Executors.newCachedThreadPool();
     }
 
     /**
@@ -64,7 +68,7 @@ public class CDSHandlerAndroid extends CDSHandler {
     public void fetchTranslationsAsync(@Nullable final String localeCode,
                                   @NonNull final FetchTranslationsCallback callback) {
         try {
-            AsyncTask.THREAD_POOL_EXECUTOR.execute(new Runnable() {
+            mExecutor.execute(new Runnable() {
                 @Override
                 public void run() {
                     LocaleData.TranslationMap result = fetchTranslations(localeCode);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TranslationMapStorageAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TranslationMapStorageAndroid.java
@@ -13,8 +13,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * A class that extends {@link TranslationMapStorage} so that translations can be read from an
- * application's raw asset files.
+ * A class that extends {@link TranslationMapStorage} so that translations can be read from the
+ * application's Assets folder.
+ * <p>
+ * Translations can be bundled in your application's Assets folder, using the Transifex command-line
+ * tool.
+ *
+ * @see TranslationMapStorage
  */
 public class TranslationMapStorageAndroid extends TranslationMapStorage {
 
@@ -36,16 +41,14 @@ public class TranslationMapStorageAndroid extends TranslationMapStorage {
     }
 
     /**
-     * Loads a {@link LocaleData.TranslationMap} from an application's raw asset files under the
+     * Loads a {@link LocaleData.TranslationMap} from an application's Assets folder under the
      * provided path.
      *
      * @param srcDirectoryPath The path to the directory containing translations in the expected
      *                         format.
      *
-     * @return The translation map or <code>null</code> if everything failed. If some locales fail
-     * to load, they won't be added in the returned map.
-     *
-     * @see TranslationMapStorage#fromDisk(File)
+     * @return The translation map or <code>null</code> if the directory isn't found or it's empty.
+     * If some locales fail to load, they won't be added in the returned map.
      */
     public @Nullable LocaleData.TranslationMap fromAssetsDirectory(@NonNull String srcDirectoryPath) {
         return fromDisk(assetFileProvider, assetFileProvider.getFile(srcDirectoryPath));
@@ -63,6 +66,10 @@ public class TranslationMapStorageAndroid extends TranslationMapStorage {
 
         public AssetFile(@NonNull AssetManager manager, @NonNull String pathname) {
             this.manager = manager;
+            // Remove trailing slash
+            if (pathname.endsWith("/")) {
+                pathname = pathname.substring(0, pathname.length() - 1);
+            }
             this.pathname = pathname;
         }
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -34,8 +34,9 @@ public class TxNative {
      * @param token The Transifex token that can be used for retrieving translations from CDS.
      * @param cdsHost An optional host for the Content Delivery Service; if set to <code>null</code>,
      *               the production host provided by Transifex is used.
-     * @param cache The translation cache that holds the translations from the CDS; MemoryCache is
-     *             used if set to <code>null</code>.
+     * @param cache The translation cache that holds the translations from the CDS;
+     * {@link com.transifex.txnative.cache.TxStandardCache TxStandardCache} is used if set to
+     *              <code>null</code>.
      * @param missingPolicy Determines how to handle translations that are not available;
      * {@link com.transifex.txnative.missingpolicy.SourceStringPolicy SourceStringPolicy} is used
      *                     if set to <code>null</code>.
@@ -110,9 +111,15 @@ public class TxNative {
     // to be reloaded after they have been fetched.
 
     /**
-     * Fetches the translations from CDS.
+     * Fetches the translations from CDS and updates the cache.
      * <p>
-     * The call returns instantly and fetches the translations asynchronously.
+     * The call returns instantly and fetches the translations asynchronously. If the translations
+     * are fetched successfully, the cache is updated.
+     * <p>
+     * Note that updating the cache may or may not affect the translations shown in the app's UI.
+     * This depends on the cache's implementation. Read
+     * {@link com.transifex.txnative.cache.TxStandardCache here} for the default cache
+     * implementation used by the TxNative SDK.
      *
      * @param localeCode An optional locale to fetch translations for; if  set to <code>null</code>,
      *                   it will fetch translations for all locales as defined in the SDK
@@ -155,7 +162,7 @@ public class TxNative {
      * Check out the installation guide regarding the usage of this method.
      *
      * @param context The service context to wrap.
-     * @return teh wrapped context.
+     * @return The wrapped context.
      */
     public static Context generalWrap(Context context) {
         if (sNativeCore == null) {

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxCache.java
@@ -13,13 +13,10 @@ import androidx.annotation.Nullable;
 public interface TxCache {
 
     /**
-     * Returns a set of the locale codes supported by cache.
-     */
-    @NonNull Set<String> getSupportedLocales();
-
-    /**
      * Gets all translations from the cache in the form of a
      * {@link LocaleData.TranslationMap TranslationMap} object.
+     * <p>
+     * The returned object should not be altered as the cache may use it internally.
      */
     @NonNull LocaleData.TranslationMap get();
 
@@ -38,6 +35,9 @@ public interface TxCache {
     /**
      * Update the cache with the provided
      * {@link LocaleData.TranslationMap TranslationMap}.
+     * <p>
+     * The translation map should not be changed after providing it to the cache, because the cache
+     * implementation may use it without making a copy.
      */
     void update(@NonNull LocaleData.TranslationMap translationMap);
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxDecoratorCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxDecoratorCache.java
@@ -1,0 +1,43 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Decorator class managing an internal cache and propagating the get() and update() protocol method
+ * calls to said cache. The class should be extended to add new capabilities.
+ */
+public class TxDecoratorCache implements TxCache {
+
+    protected final TxCache mInternalCache;
+
+    /**
+     * Creates a decorator with the provided cache.
+     *
+     * @param internalCache The cache to be used.
+     */
+    public TxDecoratorCache(@NonNull TxCache internalCache) {
+        mInternalCache = internalCache;
+    }
+
+    @NonNull
+    @Override
+    public LocaleData.TranslationMap get() {
+        return mInternalCache.get();
+    }
+
+    @Nullable
+    @Override
+    public String get(@NonNull String key, @NonNull String locale) {
+        return mInternalCache.get(key, locale);
+    }
+
+    @Override
+    public void update(@NonNull LocaleData.TranslationMap translationMap) {
+        mInternalCache.update(translationMap);
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxDiskTranslationsProvider.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxDiskTranslationsProvider.java
@@ -1,0 +1,82 @@
+package com.transifex.txnative.cache;
+
+import android.content.res.AssetManager;
+import android.util.Log;
+
+import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
+import com.transifex.txnative.TranslationMapStorageAndroid;
+
+import java.io.File;
+import java.io.IOException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Translations provider that loads translations from disk or the application's raw asset files
+ * depending on the constructor used.
+ * <p>
+ * The directory should contain the translations in the format detailed in
+ * {@link TranslationMapStorage}.
+ * <p>
+ * If an error occurs during initialization, {@link #getTranslations()} will return
+ * <code>null</code>.
+ */
+public class TxDiskTranslationsProvider implements TxTranslationsProvider {
+
+    public static final String TAG = TxDiskTranslationsProvider.class.getSimpleName();
+
+    private final LocaleData.TranslationMap mTranslations;
+
+    /**
+     * Initializes the provider with a file directory containing translations and loads them
+     * synchronously.
+     *
+     * @param srcDirectory The directory containing translations in the expected format.
+     */
+    public TxDiskTranslationsProvider(@NonNull File srcDirectory) {
+        // Make a check to avoid TranslationMapStorage complaining about directory not existing.
+        if (!srcDirectory.isDirectory()) {
+            Log.d(TAG, "Translations directory does not exist yet: " + srcDirectory.getPath());
+            mTranslations = null;
+            return;
+        }
+
+        TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        mTranslations = storage.fromDisk(srcDirectory);
+    }
+
+    /**
+     * Initializes the provider with a directory under the application's raw asset files and loads
+     * the translations synchronously.
+     *
+     * @param manager An asset manager instance.
+     * @param srcDirectoryPath The path to the directory containing translations in the expected
+     *                         format.
+     */
+    public TxDiskTranslationsProvider(@NonNull AssetManager manager, @NonNull String srcDirectoryPath) {
+        // Make a check and print a debug log
+        boolean dirContainsTranslations = false;
+        try {
+            String[] files = manager.list(srcDirectoryPath);
+            dirContainsTranslations = files.length != 0;
+        } catch (IOException ignored) {
+        }
+        if (!dirContainsTranslations) {
+            Log.d(TAG, "No translations exist in the Assets folder: " + srcDirectoryPath);
+            mTranslations = null;
+            return;
+        }
+
+        TranslationMapStorageAndroid storage = new TranslationMapStorageAndroid(manager,
+                TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        mTranslations = storage.fromAssetsDirectory(srcDirectoryPath);
+    }
+
+    @Override
+    @Nullable
+    public LocaleData.TranslationMap getTranslations() {
+        return mTranslations;
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxFileOutputCacheDecorator.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxFileOutputCacheDecorator.java
@@ -1,0 +1,82 @@
+package com.transifex.txnative.cache;
+
+import android.util.Log;
+
+import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
+import com.transifex.common.Utils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Decorator class responsible for storing any updates of the translations to a directory specified
+ * in the constructor.
+ * <p>
+ * Storing the translations happens asynchronously on a background thread after
+ * {@link #update(LocaleData.TranslationMap)} is called.
+ */
+public class TxFileOutputCacheDecorator extends TxDecoratorCache {
+
+    public static final String TAG = TxFileOutputCacheDecorator.class.getSimpleName();
+
+    private final File mDstDirectory;
+    private final Executor mExecutor;
+
+    /**
+     * Creates a new instance with a specific directory for storing the translations to the disk
+     * and an internal cache.
+     *
+     * @param dstDirectory The destination directory to write the translations to when the
+     * {@link #update(LocaleData.TranslationMap)} is called.
+     * @param internalCache The internal cache.
+     */
+    public TxFileOutputCacheDecorator(@NonNull File dstDirectory, @NonNull TxCache internalCache) {
+        this(null, dstDirectory, internalCache);
+    }
+
+    // for unit tests
+    protected TxFileOutputCacheDecorator(@Nullable Executor executor, @NonNull File dstDirectory,
+                                         @NonNull TxCache internalCache) {
+        super(internalCache);
+        mExecutor = (executor != null) ? executor : Executors.newSingleThreadExecutor();
+        mDstDirectory = dstDirectory;
+    }
+
+    /**
+     * Updates the cache with the provided translations and writes them to the specified directory
+     * after clearing its content, if any.
+     * <p>
+     * For the serialization and writing of the translations on disk, {@link TranslationMapStorage}
+     * is used internally. Each translation file uses "txstrings.json" as filename. Unlike
+     * TranslationMapStorage, pre-existing translations are not kept.
+     */
+    @Override
+    public void update(@NonNull final LocaleData.TranslationMap translationMap) {
+        super.update(translationMap);
+
+        try {
+            mExecutor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    // Delete existing translation files
+                    if (mDstDirectory.isDirectory()) {
+                        Utils.deleteDirectoryContents(mDstDirectory);
+                    }
+                    // Write translation files
+                    TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+                    HashMap<String, File> files = storage.toDisk(translationMap, mDstDirectory);
+                }
+            });
+        }
+        catch (RejectedExecutionException exception) {
+            Log.e(TAG, "Could not store updated translations: " + exception);
+        }
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxMemoryCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxMemoryCache.java
@@ -10,22 +10,15 @@ import androidx.annotation.Nullable;
 /**
  * A cache that holds translations in memory.
  */
-public class MemoryCache implements TxCache {
+public class TxMemoryCache implements TxCache {
 
     private LocaleData.TranslationMap mTranslationMap = new LocaleData.TranslationMap(0);
-
-    @NonNull
-    @Override
-    public Set<String> getSupportedLocales() {
-        return mTranslationMap.getLocales();
-    }
 
     @NonNull
     @Override
     public LocaleData.TranslationMap get() {
         return mTranslationMap;
     }
-
 
     @Nullable
     @Override
@@ -34,7 +27,6 @@ public class MemoryCache implements TxCache {
         if (localeStrings == null) {
             return  null;
         }
-
         return localeStrings.get(key);
     }
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxProviderBasedCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxProviderBasedCache.java
@@ -1,0 +1,46 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Composite class that accepts a number of translations providers and an internal cache. When
+ * initialized, the providers are used to update the internal class in the order they are added in
+ * the providers array.
+ * <p>
+ * Example usage:
+ * <pre>
+ * TxCache cache = new TxProviderBasedCache(
+ *         new TxDiskTranslationsProvider[]{
+ *                 new TxDiskTranslationsProvider(firstTranslationsDirectory),
+ *                 new TxDiskTranslationsProvider(secondTranslationsDirectory)},
+ *         new TxMemoryCache());
+ * </pre>
+ */
+public class TxProviderBasedCache extends TxDecoratorCache {
+
+    /**
+     * Creates a provider-based cache with the given internal cache and updates it with with the
+     * contents of the given translations providers.
+     * <p>
+     * The translations providers update the internal cache in the given order. If they return a
+     * <code>null</code> or empty {@link LocaleData.TranslationMap} they are
+     * ignored.
+     * <p>
+     * The providers' content is accessed synchronously in the class's constructor.
+     *
+     * @param providers An array of translations providers.
+     * @param internalCache The internal cache to be used.
+     */
+    public TxProviderBasedCache(@NonNull TxTranslationsProvider[] providers, @NonNull TxCache internalCache) {
+        super(internalCache);
+
+        for (TxTranslationsProvider provider : providers) {
+            LocaleData.TranslationMap translations = provider.getTranslations();
+            if (translations != null && !translations.isEmpty()) {
+                mInternalCache.update(provider.getTranslations());
+            }
+        }
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxReadonlyCacheDecorator.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxReadonlyCacheDecorator.java
@@ -1,0 +1,23 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Decorator class that makes the internal cache read-only so that no update operations are allowed.
+ */
+public class TxReadonlyCacheDecorator extends TxDecoratorCache {
+
+    public TxReadonlyCacheDecorator(@NonNull TxCache internalCache) {
+        super(internalCache);
+    }
+
+    /**
+     * This method is a no-op as this cache decorator is read-only.
+     */
+    @Override
+    public void update(@NonNull LocaleData.TranslationMap translationMap) {
+        // No-op
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxStandardCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxStandardCache.java
@@ -1,0 +1,73 @@
+package com.transifex.txnative.cache;
+
+import android.content.Context;
+
+import com.transifex.common.TranslationMapStorage;
+
+import java.io.File;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The standard cache configuration that the TxNative SDK is initialized with, if no other cache is
+ * provided.
+ * <p>
+ * TxStandardCache is backed by a {@link TxMemoryCache} which is initialized with existing translation
+ * files from the app's Assets folder and the app's cache directory in this specific order. When
+ * the cache is updated (when new translations become available after calling
+ * {@link com.transifex.txnative.TxNative#fetchTranslations(String)}), TxStandardCache stores the new
+ * translations in the app's cache directory. The in-memory translations are not affected by the
+ * update though. A new instance of TxStandardCache has to be created (after an app restart by default)
+ * to read the new translations saved in the app's cache directory
+ */
+public class TxStandardCache {
+
+    /**
+     * Creates a cache with the configuration explained in {@link TxStandardCache}.
+     *
+     * @param context The app's context.
+     * @param updatePolicy The update policy to be used when initializing the internal memory
+     *                     cache with the stored contents from disk. If set to <code>null</code>,
+     *                     {@link TxUpdateFilterCache#REPLACE_ALL} is used.
+     * @param cachedTranslationsDirectory The directory where the cache will store new translations
+     *                                    when available and read translations from when initialized.
+     *                                    If set to <code>null</code> it uses a "txnative" folder in
+     *                                    the app's internal cache directory.
+     *
+     * @return A TxCache instance.
+     */
+    public static TxCache getCache(@NonNull Context context,
+                                   @Nullable @TxUpdateFilterCache.TxCacheUpdatePolicy Integer updatePolicy,
+                                   @Nullable File cachedTranslationsDirectory) {
+
+        if (updatePolicy == null) {
+            updatePolicy = TxUpdateFilterCache.REPLACE_ALL;
+        }
+        if (cachedTranslationsDirectory == null) {
+            cachedTranslationsDirectory = new File(context.getCacheDir() + File.separator
+                    + TranslationMapStorage.DEFAULT_TRANSLATIONS_DIR_NAME);
+        }
+
+        TxTranslationsProvider[] providers = new TxDiskTranslationsProvider[] {
+                new TxDiskTranslationsProvider(
+                        context.getAssets(),
+                        TranslationMapStorage.DEFAULT_TRANSLATIONS_DIR_NAME),
+                new TxDiskTranslationsProvider(cachedTranslationsDirectory)
+        };
+
+        return new TxFileOutputCacheDecorator(
+                cachedTranslationsDirectory,
+                new TxReadonlyCacheDecorator(
+                        new TxProviderBasedCache(
+                                providers,
+                                new TxUpdateFilterCache(
+                                        updatePolicy,
+                                        new TxMemoryCache()
+                                )
+                        )
+                )
+        );
+    }
+
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxTranslationsProvider.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxTranslationsProvider.java
@@ -1,0 +1,20 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import androidx.annotation.Nullable;
+
+/**
+ * An interface for classes that act as providers of translations (e.g. extracting them from a file)
+ */
+public interface TxTranslationsProvider {
+
+    /**
+     * Returns the translations from the provider.
+     *
+     * @return A {@link LocaleData.TranslationMap} object or <code>null</code> if an error occurred.
+     * The returned map can be empty if an error occurred.
+     */
+    @Nullable
+    LocaleData.TranslationMap getTranslations();
+}

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
@@ -1,0 +1,148 @@
+package com.transifex.txnative.cache;
+
+import android.text.TextUtils;
+
+import com.transifex.common.LocaleData;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+
+
+/**
+ * Decorator class that updates the internal cache using a certain update policy when the
+ * {@link #update(LocaleData.TranslationMap)} method is called.
+ *
+ * @see TxCacheUpdatePolicy
+ */
+public class TxUpdateFilterCache extends TxDecoratorCache {
+
+    /**
+     * Update policy that specifies the way that the internal cache is updated with new
+     * translations.
+     * <p>
+     * You can find an easy to understand table containing a number of cases and how each policy
+     * updates the cache below:
+     *
+     * <pre>
+     *     {@code
+     * | Key || Cache | New  || Replace All   | Update using Translated        |
+     * |-----||-------|------||---------------|--------------------------------|
+     * | a   || "a"   | -    || -             | "a"                            |
+     * | b   || "b"   | "B"  || "B"           | "B"                            |
+     * | c   || "c"   | ""   || ""            | "c"                            |
+     * | d   || ""    | -    || -             | ""                             |
+     * | e   || ""    | "E"  || "E"           | "E"                            |
+     * | f   || -     | "F"  || "F"           | "F"                            |
+     * | g   || -     | ""   || ""            | -                              |
+     * }
+     * </pre>
+     * Here's an example on how to read the table above:
+     * <ul>
+     *     <li>given a string with <code>key="c"</code></li>
+     *     <li>and a cache that has <code>"c"</code> as the stored value for this key (<code>"c" -> "c"</code>)</li>
+     *     <li>if an empty translation arrives for this string (<code>""</code>)
+     *     <ul>
+     *         <li>if policy is <code>REPLACE_ALL</code>, then the cache will be updated so that
+     *         (<code>"c" -> ""</code>)</li>
+     *         <li>in contrast to that, if policy is <code>UPDATE_USING_TRANSLATED</code>, then the
+     *         cache will stay as is (<code>"c" -> "c"</code>), because the new translation is
+     *         empty</li>
+     *     </ul>
+     *     </li>
+     * </ul>
+     * A <code>"-"</code> value means that the respective key does not exist. For example:
+     * <ul>
+     *     <li>given a string with <code>key="f"</code></li>
+     *     <li>and a cache that has no entry with <code>"f"</code> as a key</li>
+     *     <li>if a translation arrives for this string (<code>"f" -> "F"</code>)
+     *     <ul>
+     *         <li>if policy is <code>REPLACE_ALL</code>, then the cache will be updated by adding a
+     *         new entry so that (<code>"f" -> "F"</code>)</li>
+     *         <li>if policy is <code>UPDATE_USING_TRANSLATED</code>, then the same will happen,
+     *         since the new translation is not empty</li>
+     *     </ul>
+     *     </li>
+     * </ul>
+     *
+     */
+    @IntDef({REPLACE_ALL, UPDATE_USING_TRANSLATED})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface TxCacheUpdatePolicy {}
+
+    /**
+     * Discards the existing cache entries completely and populates the cache with the new entries,
+     * even if they contain empty translations.
+     */
+    public static final int REPLACE_ALL = 0;
+    /**
+     * Updates the existing cache with the new entries that have a non-empty translation.
+     */
+    public static final int UPDATE_USING_TRANSLATED = 1;
+
+    private final @TxCacheUpdatePolicy int mPolicy;
+
+    /**
+     * Creates a new instance having the provided {@link TxCacheUpdatePolicy TxCacheUpdatePolicy}
+     * and internal cache.
+     *
+     * @param policy One of the available {@link TxCacheUpdatePolicy update policies}.
+     * @param internalCache The internal cache to be used.
+     */
+    public TxUpdateFilterCache(@TxCacheUpdatePolicy int policy, @NonNull TxCache internalCache) {
+        super(internalCache);
+        mPolicy = policy;
+    }
+
+    /**
+     * Updates the internal cache with the provided translations using the update policy specified
+     * in the constructor.
+     * <p>
+     * Note that after calculating the new translations with the current update policy, the internal
+     * cache's {@link TxCache#update(LocaleData.TranslationMap)} method is called to set them.
+     * Depending on the cache's implementation, the actual result may be different to the calculated
+     * one.
+     */
+    @Override
+    public void update(@NonNull LocaleData.TranslationMap translationMap) {
+        if (mPolicy == REPLACE_ALL) {
+            super.update(translationMap);
+        }
+        else if (mPolicy == UPDATE_USING_TRANSLATED) {
+            // Make a copy of the internal cache's TranslationMap, in order to apply the updates there
+            LocaleData.TranslationMap updatedTranslations = new LocaleData.TranslationMap(get());
+
+            // For each locale
+            for (String locale : translationMap.getLocales()) {
+                LocaleData.LocaleStrings localeStrings = translationMap.get(locale);
+                if (localeStrings == null) {
+                    continue; // Can't happen. Just to suppress lint
+                }
+                LocaleData.LocaleStrings updatedLocaleStrings = updatedTranslations.get(locale);
+
+                // For each key-value entry of localeStrings
+                for (Map.Entry<String, LocaleData.StringInfo> entry : localeStrings.getMap().entrySet()) {
+                    // Make sure that the new entry contains a translation, otherwise don't process it.
+                    if (entry.getValue() == null || TextUtils.isEmpty(entry.getValue().string)) {
+                        continue;
+                    }
+
+                    // If needed, create new LocaleStrings object and add it to the updated
+                    // translation map
+                    if (updatedLocaleStrings == null) {
+                        updatedLocaleStrings = new LocaleData.LocaleStrings(localeStrings.getMap().size());
+                        updatedTranslations.put(locale, updatedLocaleStrings);
+                    }
+
+                    updatedLocaleStrings.put(entry.getKey(), entry.getValue());
+                }
+
+                // Update the internal cache with the updated translations
+                super.update(updatedTranslations);
+            }
+        }
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
@@ -7,7 +7,7 @@ import android.text.Spanned;
 import android.text.style.StyleSpan;
 
 import com.transifex.common.LocaleData;
-import com.transifex.txnative.cache.MemoryCache;
+import com.transifex.txnative.cache.TxMemoryCache;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +29,12 @@ import static org.junit.Assert.assertThrows;
 @Config(sdk = Build.VERSION_CODES.P)
 public class NativeCoreTest {
 
+    // The tests rely on the following directories:
+    //
+    // test/res/values
+    // test/res/values-el
+    // test/res/values-es
+
     private Context mockContext;
 
     @Before
@@ -37,7 +43,7 @@ public class NativeCoreTest {
         mockContext = ApplicationProvider.getApplicationContext();
     }
 
-    private MemoryCache getElMemoryCache() {
+    private TxMemoryCache getElMemoryCache() {
         HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
         dic2.put("tx_test_key", new LocaleData.StringInfo("test ελ tx"));
         LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
@@ -45,13 +51,13 @@ public class NativeCoreTest {
         LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
         translationMap.put("el", elStrings);
 
-        MemoryCache memoryCache = new MemoryCache();
+        TxMemoryCache memoryCache = new TxMemoryCache();
         memoryCache.update(translationMap);
 
         return memoryCache;
     }
 
-    private MemoryCache getElSpanMemoryCache() {
+    private TxMemoryCache getElSpanMemoryCache() {
         HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
         dic2.put("tx_test_key", new LocaleData.StringInfo("this is <b>bold</b>"));
         LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
@@ -59,13 +65,13 @@ public class NativeCoreTest {
         LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
         translationMap.put("el", elStrings);
 
-        MemoryCache memoryCache = new MemoryCache();
+        TxMemoryCache memoryCache = new TxMemoryCache();
         memoryCache.update(translationMap);
 
         return memoryCache;
     }
 
-    private MemoryCache getElHTMLEscapedMemoryCache() {
+    private TxMemoryCache getElHTMLEscapedMemoryCache() {
         HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
         dic2.put("tx_test_key", new LocaleData.StringInfo("this is &lt;b>bold&lt;/b>"));
         LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
@@ -73,16 +79,16 @@ public class NativeCoreTest {
         LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
         translationMap.put("el", elStrings);
 
-        MemoryCache memoryCache = new MemoryCache();
+        TxMemoryCache memoryCache = new TxMemoryCache();
         memoryCache.update(translationMap);
 
         return memoryCache;
     }
 
-    private MemoryCache getEmptyMemoryCache() {
+    private TxMemoryCache getEmptyMemoryCache() {
         LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
 
-        MemoryCache memoryCache = new MemoryCache();
+        TxMemoryCache memoryCache = new TxMemoryCache();
         memoryCache.update(translationMap);
 
         return memoryCache;
@@ -95,7 +101,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -111,7 +117,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -127,7 +133,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -142,7 +148,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         final NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -160,7 +166,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         final NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -176,7 +182,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         final NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         nativeCore.setTestMode(true);
         final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
@@ -193,7 +199,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         nativeCore.setTestMode(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
@@ -211,7 +217,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElSpanMemoryCache();
+        TxMemoryCache elMemoryCache = getElSpanMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         nativeCore.setSupportSpannable(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
@@ -242,7 +248,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
+        TxMemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         nativeCore.setSupportSpannable(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
@@ -275,7 +281,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         nativeCore.setSupportSpannable(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
@@ -292,7 +298,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElSpanMemoryCache();
+        TxMemoryCache elMemoryCache = getElSpanMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
@@ -324,7 +330,7 @@ public class NativeCoreTest {
                 "en",
                 new String[]{"en", "el"},
                 null);
-        MemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
+        TxMemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxDecoratorCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxDecoratorCacheTest.java
@@ -1,0 +1,53 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class TxDecoratorCacheTest {
+
+    // In these tests, we check that the internal cache methods are called by TxDecoratorCache as
+    // expected.
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void testGetAll() {
+        TxMemoryCache internalCache = mock(TxMemoryCache.class);
+
+        TxDecoratorCache decoratorCache = new TxDecoratorCache(internalCache);
+        decoratorCache.get();
+
+        verify(internalCache, times(1)).get();
+    }
+
+    @Test
+    public void testGet() {
+        TxMemoryCache internalCache = mock(TxMemoryCache.class);
+
+        TxDecoratorCache decoratorCache = new TxDecoratorCache(internalCache);
+        decoratorCache.get("key1", "el");
+
+        verify(internalCache, times(1)).get("key1", "el");
+    }
+
+    @Test
+    public void testUpdate() {
+        TxMemoryCache internalCache = mock(TxMemoryCache.class);
+
+        TxDecoratorCache decoratorCache = new TxDecoratorCache(internalCache);
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(0);
+        decoratorCache.update(map);
+
+        verify(internalCache, times(1)).update(map);
+    }
+
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxDiskTranslationsProviderTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxDiskTranslationsProviderTest.java
@@ -1,0 +1,82 @@
+package com.transifex.txnative.cache;
+
+import android.os.Build;
+
+import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
+import com.transifex.common.Utils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.P)
+public class TxDiskTranslationsProviderTest {
+
+    File tempDir = new File("build" + File.separator + "unitTestTempDir");
+
+    @Before
+    public void setUp() {
+        if (tempDir.exists()) {
+            Utils.deleteDirectory(tempDir);
+        }
+    }
+
+    @After
+    public void Teardown() {
+        if (tempDir.exists()) {
+            boolean deleted = Utils.deleteDirectory(tempDir);
+            if (!deleted) {
+                System.out.println("Could not delete tmp dir after test. Next test may fail.");
+            }
+        }
+    }
+
+    private LocaleData.TranslationMap getElTranslationMap() {
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(1);
+        elStrings.put("tx_test_key", new LocaleData.StringInfo("test ελ tx"));
+
+        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(1);
+        translationMap.put("el", elStrings);
+
+        return translationMap;
+    }
+
+    @Test
+    public void testGetTranslations_normal() {
+        assertThat(tempDir.mkdirs()).isTrue();
+
+        LocaleData.TranslationMap map = getElTranslationMap();
+        TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        storage.toDisk(map, tempDir);
+
+        TxDiskTranslationsProvider provider = new TxDiskTranslationsProvider(tempDir);
+
+        assertThat(provider.getTranslations()).isEqualTo(map);
+    }
+
+    @Test
+    public void testGetTranslations_dirDoesNotExist_returnNullTranslationMap() {
+        TxDiskTranslationsProvider provider = new TxDiskTranslationsProvider(tempDir);
+
+        assertThat(provider.getTranslations()).isNull();
+    }
+
+    @Test
+    public void testGetTranslations_emptyDir_returnNullTranslationMap() {
+        assertThat(tempDir.mkdirs()).isTrue();
+
+        TxDiskTranslationsProvider provider = new TxDiskTranslationsProvider(tempDir);
+
+        assertThat(provider.getTranslations()).isNull();
+    }
+
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxFileOutputCacheDecoratorTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxFileOutputCacheDecoratorTest.java
@@ -1,0 +1,113 @@
+package com.transifex.txnative.cache;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.transifex.common.LocaleData;
+import com.transifex.common.TranslationMapStorage;
+import com.transifex.common.Utils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TxFileOutputCacheDecoratorTest {
+
+    File tempDir = new File("build" + File.separator + "unitTestTempDir");
+
+    @Before
+    public void setUp() {
+        if (tempDir.exists()) {
+            Utils.deleteDirectory(tempDir);
+        }
+    }
+
+    @After
+    public void Teardown() {
+        if (tempDir.exists()) {
+            boolean deleted = Utils.deleteDirectory(tempDir);
+            if (!deleted) {
+                System.out.println("Could not delete tmp dir after test. Next test may fail.");
+            }
+        }
+    }
+
+    private LocaleData.TranslationMap getElTranslationMap() {
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(1);
+        elStrings.put("tx_test_key", new LocaleData.StringInfo("test ελ tx"));
+
+        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(1);
+        translationMap.put("el", elStrings);
+
+        return translationMap;
+    }
+
+    @Test
+    public void testUpdate_normal_writeTranslations() {
+        assertThat(tempDir.mkdirs()).isTrue();
+
+        TxMemoryCache internalCache = new TxMemoryCache();
+        TxFileOutputCacheDecorator fileOutputCache = new TxFileOutputCacheDecorator(
+                MoreExecutors.directExecutor(), tempDir, internalCache);
+        LocaleData.TranslationMap map = getElTranslationMap();
+        fileOutputCache.update(map);
+
+        // Check that internal cache is updated
+        assertThat(fileOutputCache.get()).isEqualTo(map);
+
+        // Check that the translations on disk are correct
+        TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        File elStringFile = new File(tempDir.getPath() + File.separator + "el"
+                + File.separator + TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        assertThat(elStringFile.exists()).isTrue();
+        LocaleData.TranslationMap readMap = storage.fromDisk(tempDir);
+        assertThat(readMap).isEqualTo(map);
+    }
+
+    @Test
+    public void testUpdate_translationFileExistsForNonSupportedLocale_fileIsDeleted() {
+        // Create a pre-existing translation file for de
+        File localeDir = new File(tempDir.getAbsoluteFile() + File.separator + "de");
+        boolean localeDirCreated =  localeDir.mkdirs();
+        assertThat(localeDirCreated).isTrue();
+        File dummyDeStringFile = new File(localeDir + File.separator + "strings.txt");
+        boolean dummyFileWritten = false;
+        try {
+            FileOutputStream outputStream = new FileOutputStream(dummyDeStringFile);
+            String dummyContent = "some text";
+            outputStream.write(dummyContent.getBytes(StandardCharsets.UTF_8));
+            outputStream.close();
+            dummyFileWritten = true;
+        } catch (IOException ignored) {}
+        assertThat(dummyFileWritten).isTrue();
+
+        TxMemoryCache internalCache = new TxMemoryCache();
+        TxFileOutputCacheDecorator fileOutputCache = new TxFileOutputCacheDecorator(
+                MoreExecutors.directExecutor(), tempDir, internalCache);
+        LocaleData.TranslationMap map = getElTranslationMap();
+        fileOutputCache.update(map);
+
+        // Check that previous de folder is deleted and new el is created
+        assertThat(tempDir.list()).asList().containsExactly("el");
+
+        // Check that old file doesn't exist
+        assertThat(dummyDeStringFile.exists()).isFalse();
+
+        // Check that internal cache is updated
+        assertThat(fileOutputCache.get()).isEqualTo(map);
+
+        // Check that the translations on disk are correct
+        TranslationMapStorage storage = new TranslationMapStorage(TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        File elStringFile = new File(tempDir.getPath() + File.separator + "el"
+                + File.separator + TranslationMapStorage.DEFAULT_TRANSLATION_FILENAME);
+        assertThat(elStringFile.exists()).isTrue();
+        LocaleData.TranslationMap readMap = storage.fromDisk(tempDir);
+        assertThat(readMap).isEqualTo(map);
+    }
+
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxMemoryCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxMemoryCacheTest.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 
 import static com.google.common.truth.Truth.assertThat;
 
-public class MemoryCacheTest {
+public class TxMemoryCacheTest {
 
     private static LocaleData.TranslationMap getDummyTranslationMap() {
         HashMap<String, LocaleData.StringInfo> dic1 = new HashMap<>();
@@ -38,64 +38,50 @@ public class MemoryCacheTest {
     }
 
     @Test
-    public void testSupportedLocales_emptyCache() {
-        MemoryCache cache = new MemoryCache();
-
-        assertThat(cache.getSupportedLocales()).isEmpty();
-    }
-
-    @Test
-    public void testSupportedLocales_normal() {
-        MemoryCache cache = new MemoryCache();
-        cache.update(getDummyTranslationMap());
-
-        assertThat(cache.getSupportedLocales()).containsExactly("el", "es");
-    }
-
-    @Test
-    public void testGet_emptyCache() {
-        MemoryCache cache = new MemoryCache();
+    public void testGet_emptyCache_returnNullString() {
+        TxMemoryCache cache = new TxMemoryCache();
 
         assertThat(cache.get("key1", "el")).isNull();
     }
 
     @Test
-    public void testGet_localeNotSupported() {
-        MemoryCache cache = new MemoryCache();
+    public void testGet_localeNotSupported_returnNullString() {
+        TxMemoryCache cache = new TxMemoryCache();
         cache.update(getDummyTranslationMap());
 
         assertThat(cache.get("key1", "de")).isNull();
     }
 
     @Test
-    public void testGet_normal() {
-        MemoryCache cache = new MemoryCache();
+    public void testGet_normal_returnString() {
+        TxMemoryCache cache = new TxMemoryCache();
         cache.update(getDummyTranslationMap());
 
         assertThat(cache.get("key1", "el")).isEqualTo("val1");
     }
 
     @Test
-    public void testGet_updateCalledMultipleTimes() {
-        MemoryCache cache = new MemoryCache();
+    public void testGet_updateCalledMultipleTimes_returnStringFromLatestUpdate() {
+        TxMemoryCache cache = new TxMemoryCache();
         cache.update(getDummyTranslationMap());
 
         cache.update(getDummyTranslationMap2());
 
         assertThat(cache.get("key1", "el")).isNull();
+        assertThat(cache.get("key1", "de")).isEqualTo("val1 de");
     }
 
     @Test
     public void testGetAll_normal() {
-        MemoryCache cache = new MemoryCache();
+        TxMemoryCache cache = new TxMemoryCache();
         cache.update(getDummyTranslationMap());
 
         assertThat(cache.get()).isEqualTo(getDummyTranslationMap());
     }
 
     @Test
-    public void testGetAll_emptyCache() {
-        MemoryCache cache = new MemoryCache();
+    public void testGetAll_emptyCache_returnEmptyMap() {
+        TxMemoryCache cache = new TxMemoryCache();
 
         assertThat(cache.get()).isNotNull();
         assertThat(cache.get().getLocales()).isEmpty();

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxProviderBasedCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxProviderBasedCacheTest.java
@@ -1,0 +1,72 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TxProviderBasedCacheTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private LocaleData.TranslationMap getElTranslationMap1() {
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(1);
+        elStrings.put("tx_test_key", new LocaleData.StringInfo("test ελ tx"));
+
+        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(1);
+        translationMap.put("el", elStrings);
+
+        return translationMap;
+    }
+
+    private LocaleData.TranslationMap getElTranslationMap2() {
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(1);
+        elStrings.put("tx_test_key", new LocaleData.StringInfo("test ελ tx 2"));
+
+        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(1);
+        translationMap.put("el", elStrings);
+
+        return translationMap;
+    }
+
+    @Test
+    public void testConstructor_twoProviders_callInternalCacheUpdateInSpecificOrder() {
+        TxTranslationsProvider provider1 = new TxTranslationsProvider() {
+
+            @Override
+            public LocaleData.TranslationMap getTranslations() {
+                return getElTranslationMap1();
+            }
+        };
+
+        TxTranslationsProvider provider2 = new TxTranslationsProvider() {
+
+            @Override
+            public LocaleData.TranslationMap getTranslations() {
+                return getElTranslationMap2();
+            }
+        };
+
+        TxCache internalCache = mock(TxCache.class);
+        TxTranslationsProvider[] providers = new TxTranslationsProvider[]{provider1, provider2};
+        TxProviderBasedCache providerBasedCache = new TxProviderBasedCache(providers, internalCache);
+
+        // We check if the internal cache's update() was called exactly 2 times, passing provider1
+        // content in the first time and provider2 content the second time.
+        verify(internalCache, times(2)).update(any(LocaleData.TranslationMap.class));
+        InOrder orderVerifier = inOrder(internalCache);
+        orderVerifier.verify(internalCache, times(1)).update(getElTranslationMap1());
+        orderVerifier.verify(internalCache, times(1)).update(getElTranslationMap2());
+        orderVerifier.verifyNoMoreInteractions();
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxReadonlyCacheDecoratorTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxReadonlyCacheDecoratorTest.java
@@ -1,0 +1,43 @@
+package com.transifex.txnative.cache;
+
+import com.transifex.common.LocaleData;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TxReadonlyCacheDecoratorTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void testUpdate_notCallInternalUpdate() {
+        TxMemoryCache internalCache = mock(TxMemoryCache.class);
+        TxReadonlyCacheDecorator readOnlyCache = new TxReadonlyCacheDecorator(internalCache);
+
+        // Make sure that the internal cache's update() was not called after calling the readOnlyCache's
+        // update
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(0);
+        readOnlyCache.update(map);
+        verify(internalCache, times(0)).update(map);
+    }
+
+    @Test
+    public void testGet_callInternalGet() {
+        TxMemoryCache internalCache = mock(TxMemoryCache.class);
+        TxReadonlyCacheDecorator readOnlyCache = new TxReadonlyCacheDecorator(internalCache);
+
+        // Make sure that the internal cache's get() was called after calling the readOnlyCache's
+        // get()
+        readOnlyCache.get();
+        verify(internalCache, times(1)).get();
+    }
+
+
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxUpdateFilterCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxUpdateFilterCacheTest.java
@@ -1,0 +1,129 @@
+package com.transifex.txnative.cache;
+
+import android.os.Build;
+
+import com.transifex.common.LocaleData;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+// We need roboelectric to emulate TextUtils
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.P)
+public class TxUpdateFilterCacheTest {
+
+    // The following Translation Maps are based on the table found in TxCacheUpdatePolicy
+
+    private LocaleData.TranslationMap getTranslations1() {
+        LocaleData.LocaleStrings strings = new LocaleData.LocaleStrings(10);
+        strings.put("a", new LocaleData.StringInfo("a"));
+        strings.put("b", new LocaleData.StringInfo("b"));
+        strings.put("c", new LocaleData.StringInfo("c"));
+        strings.put("d", new LocaleData.StringInfo(""));
+        strings.put("e", new LocaleData.StringInfo(""));
+
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(1);
+        map.put("el", strings);
+
+        return map;
+    }
+
+    private LocaleData.TranslationMap getTranslations2() {
+        LocaleData.LocaleStrings strings = new LocaleData.LocaleStrings(10);
+        strings.put("b", new LocaleData.StringInfo("B"));
+        strings.put("c", new LocaleData.StringInfo(""));
+        strings.put("e", new LocaleData.StringInfo("E"));
+        strings.put("f", new LocaleData.StringInfo("F"));
+        strings.put("g", new LocaleData.StringInfo(""));
+
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(1);
+        map.put("el", strings);
+
+        return map;
+    }
+
+    // This is the expected result of applying getTranslations2() on getTranslations1() using
+    // TxUpdateFilterCache.UPDATE_USING_TRANSLATED
+    private LocaleData.TranslationMap getTranslationsForUpdateUsingTranslatedGroundTruth() {
+        LocaleData.LocaleStrings strings = new LocaleData.LocaleStrings(10);
+        strings.put("a", new LocaleData.StringInfo("a"));
+        strings.put("b", new LocaleData.StringInfo("B"));
+        strings.put("c", new LocaleData.StringInfo("c"));
+        strings.put("d", new LocaleData.StringInfo(""));
+        strings.put("e", new LocaleData.StringInfo("E"));
+        strings.put("f", new LocaleData.StringInfo("F"));
+
+        LocaleData.TranslationMap map = new LocaleData.TranslationMap(1);
+        map.put("el", strings);
+
+        return map;
+    }
+
+    @Test
+    public void testUpdate_replaceAllPolicy_getCorrectMap() {
+        int policy = TxUpdateFilterCache.REPLACE_ALL;
+        TxMemoryCache internalCache = new TxMemoryCache();
+        internalCache.update(getTranslations1());
+        TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
+        updateFilterCache.update(getTranslations2());
+
+        assertThat(updateFilterCache.get()).isEqualTo(getTranslations2());
+    }
+
+    @Test
+    public void testUpdate_updateUsingTranslatedPolicy_getCorrectMap() {
+        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        TxMemoryCache internalCache = new TxMemoryCache();
+        internalCache.update(getTranslations1());
+        TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
+        updateFilterCache.update(getTranslations2());
+
+        assertThat(updateFilterCache.get()).isEqualTo(getTranslationsForUpdateUsingTranslatedGroundTruth());
+    }
+
+    @Test
+    public void testUpdate_replaceAllAndReadOnlyInternalCachePolicy_keepInternalCacheUnchanged() {
+        // This tests makes sure that TxUpdateFilterCache updates the internal cache by calling
+        // its update() method and not by accidentally changing the internal cache's map
+
+        int policy = TxUpdateFilterCache.REPLACE_ALL;
+        TxMemoryCache internalCache = new TxMemoryCache();
+        internalCache.update(getTranslations1());
+        TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, new TxReadonlyCacheDecorator(internalCache));
+        updateFilterCache.update(getTranslations2());
+
+        assertThat(updateFilterCache.get()).isEqualTo(getTranslations1());
+    }
+
+    @Test
+    public void testUpdate_updateUsingTranslatedPolicyAndReadOnlyInternalCache_keepInternalCacheUnchanged() {
+        // This tests makes sure that TxUpdateFilterCache updates the internal cache by calling
+        // its update() method and not by accidentally changing the internal cache's map
+
+        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        TxMemoryCache internalCache = new TxMemoryCache();
+        internalCache.update(getTranslations1());
+        TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, new TxReadonlyCacheDecorator(internalCache));
+        updateFilterCache.update(getTranslations2());
+
+        assertThat(updateFilterCache.get()).isEqualTo(getTranslations1());
+    }
+
+    @Test
+    public void testUpdate_updateUsingTranslatedPolicyAndEmptyInternalCache_addNewLocale() {
+        // We make sure that a new locale can be added when UPDATE_USING_TRANSLATED is used.
+
+        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        TxMemoryCache internalCache = new TxMemoryCache();
+        TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
+        updateFilterCache.update(getTranslations1());
+
+        assertThat(updateFilterCache.get().getLocales()).containsExactly("el");
+        assertThat(updateFilterCache.get("a", "el")).isEqualTo("a");
+        assertThat(updateFilterCache.get("d", "el")).isNull();
+    }
+}


### PR DESCRIPTION
Moved exising cache files in their own  cache package.

Added new internfaces and classes.

Created unit tests and intrumented tests. Added files at
androidTest/assets directory so that they are accessible
during instrumented testing.

Updated TxNative and NativeCore so that TxStandardCache
is used, instead of TxMemoryCache. Updated the documentation.
When NativeCore received a null or empty map from CDSHandler
it does not update the cache.

Added copy constructor for LocaleStrings and TranslationMap.

Changed TranslationMapStorage#fromDisk() behavior so that it
returns null instead of an empty map when no translations are found.
This is because distinguishing between no folder found and no
translations found is not that easy in all cases.

Updated the name of existing unit tests.

Updated readme.