### PR TITLE
Implement plurals

### DIFF
--- a/TransifexNativeSDK/app/build.gradle
+++ b/TransifexNativeSDK/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
         // https://stackoverflow.com/a/41345440/941314
         // Needed for multilingual-support after Android N
-        resConfigs "en", "el"
+        resConfigs "en", "el", "de", "fr", "ar", "sl"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/TransifexNativeSDK/app/src/main/res/layout/activity_main.xml
+++ b/TransifexNativeSDK/app/src/main/res/layout/activity_main.xml
@@ -22,103 +22,110 @@
         android:layout_height="match_parent"
         tools:context=".MainActivity">
 
-        <LinearLayout
-            android:id="@+id/linearLayout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="vertical"
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:id="@+id/hello_label"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/linearLayout"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/hello_world"
-                android:textAlignment="center" />
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/welcome_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/hello_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/hello_world"
+                    android:layout_marginTop="20dp"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:id="@+id/array_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/welcome_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:id="@+id/plural_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/array_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:id="@+id/formatted_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/plural_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:id="@+id/styled_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:autoLink="web"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/formatted_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="?attr/theme_string"
-                android:textAlignment="center" />
+                <TextView
+                    android:id="@+id/styled_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:autoLink="web"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <TextView
-                android:id="@+id/reference_use"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="This is a temporary text"
-                android:textAlignment="center" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="?attr/theme_string"
+                    android:textAlignment="center" />
 
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="@string/press_me" />
+                <TextView
+                    android:id="@+id/reference_use"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="This is a temporary text"
+                    android:textAlignment="center" />
 
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/image_description"
-                android:src="@android:drawable/btn_star"
-                android:tooltipText="@string/tooltip" />
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/press_me" />
 
-            <EditText
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:hint="@string/edit_text_hint"
-                android:importantForAutofill="no"
-                android:inputType="text"
-                android:textAlignment="center" />
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/image_description"
+                    android:src="@android:drawable/btn_star"
+                    android:tooltipText="@string/tooltip" />
 
-        </LinearLayout>
+                <EditText
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:hint="@string/edit_text_hint"
+                    android:importantForAutofill="no"
+                    android:inputType="text"
+                    android:textAlignment="center" />
+
+            </LinearLayout>
+        </ScrollView>
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -166,20 +166,23 @@ public class MainClass {
                     mainClass.hostURL);
             LocaleData.TxPostResponseData response = cdsHandler.pushSourceStrings(postData);
 
-            if (response != null) {
+            if (response != null && response.isSuccessful()) {
                 System.out.println("Source strings pushed successfully to CDS");
 
                 System.out.println(getDetailsString(response));
-
-                String errorString = getErrorString(response);
-                if (errorString != null) {
-                    System.out.println(errorString);
-                }
 
                 return 0;
             }
             else {
                 System.out.println("Error while pushing source strings to CDS");
+
+                if (response != null) {
+                    String errorString = getErrorString(response);
+                    if (errorString != null) {
+                        System.out.println(errorString);
+                    }
+                }
+
                 return 1;
             }
         }
@@ -205,21 +208,24 @@ public class MainClass {
                     mainClass.hostURL);
             LocaleData.TxPostResponseData response = cdsHandler.pushSourceStrings(postData);
 
-            if (response != null) {
+            if (response != null && response.isSuccessful()) {
                 System.out.println("Source strings cleared from CDS");
 
                 String details = String.format(Locale.US, "%d strings deleted", response.deleted);
                 System.out.println(details);
 
-                String errorString = getErrorString(response);
-                if (errorString != null) {
-                    System.out.println(errorString);
-                }
-
                 return 0;
             }
             else {
                 System.out.println("Error while contacting CDS");
+
+                if (response != null) {
+                    String errorString = getErrorString(response);
+                    if (errorString != null) {
+                        System.out.println(errorString);
+                    }
+                }
+
                 return 1;
             }
         }

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
@@ -115,7 +115,13 @@ class StringXMLConverter {
                     String itemString = getXMLText(item);
                     sb.setPlural(quantity, itemString);
                 }
-                Plurals plurals = sb.buildString();
+                Plurals plurals;
+                try {
+                    plurals = sb.buildString();
+                }
+                catch (Plurals.InvalidPluralsConfiguration e) {
+                    throw new XMLConverterException("\"other\" is not specified for Plurals resource \"" + key + "\"");
+                }
                 stringMap.put(key, new LocaleData.StringInfo(plurals.toICUString()));
             }
         }

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
@@ -1,6 +1,7 @@
 package com.transifex.clitool;
 
 import com.transifex.common.LocaleData;
+import com.transifex.common.Plurals;
 
 import org.jdom2.Attribute;
 import org.jdom2.Document;
@@ -74,7 +75,7 @@ class StringXMLConverter {
      * The strings are inserted in the order found in the XML.
      *
      * @param document The XML representation of an Android XML resource file containing strings.
-     * @param stringMap The map to update with the strings extracted from the string file.
+     * @param stringMap The map to update with the strings extracted from the document.
      *
      * @throws JDOMException when the file is not in a valid XML format.
      * @throws XMLConverterException when the XML file does not have the expected format.
@@ -95,12 +96,27 @@ class StringXMLConverter {
                 continue;
             }
 
-            // TODO: support string-array and plurals
+            // TODO: support string-array
 
             if (child.getName().equals("string")) {
                 String key = child.getAttribute("name").getValue();
                 String string = getXMLText(child);
                 stringMap.put(key, new LocaleData.StringInfo(string));
+            }
+            else if (child.getName().equals("plurals")) {
+                String key = child.getAttribute("name").getValue();
+                List<Element> pluralItems = child.getChildren("item");
+                if (pluralItems.isEmpty()) {
+                    continue;
+                }
+                Plurals.Builder sb = new Plurals.Builder();
+                for (Element item : pluralItems) {
+                    String quantity = item.getAttribute("quantity").getValue();
+                    String itemString = getXMLText(item);
+                    sb.setPlural(quantity, itemString);
+                }
+                Plurals plurals = sb.buildString();
+                stringMap.put(key, new LocaleData.StringInfo(plurals.toICUString()));
             }
         }
     }

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
@@ -161,8 +161,9 @@ public class MainClassTest {
         String postBody = recordedRequest.getBody().readUtf8();
         Gson gson = new Gson();
         LocaleData.TxPostData parsedPostData = gson.fromJson(postBody, LocaleData.TxPostData.class);
-        assertThat(parsedPostData.data.keySet()).containsExactly("tx_test_key");
+        assertThat(parsedPostData.data.keySet()).containsExactly("tx_test_key", "tx_plural_test_key").inOrder();
         assertThat(parsedPostData.data.get("tx_test_key").string).isEqualTo("test");
+        assertThat(parsedPostData.data.get("tx_plural_test_key").string).isEqualTo("{cnt, plural, one {car} two {car 2} other {cars}}");
     }
 
     @Test
@@ -170,6 +171,9 @@ public class MainClassTest {
         // This test relies on having the following files:
         // txsdk/src/test/res/values/strings.xml
         // txsdk/src/test/res/values-el/strings.xml"
+
+        // The second file contains the same keys as the first file but with a different values. We
+        // expect to see the last file's value in the pushed strings.
 
         server.setDispatcher(getPostDispatcher());
 
@@ -190,8 +194,9 @@ public class MainClassTest {
         String postBody = recordedRequest.getBody().readUtf8();
         Gson gson = new Gson();
         LocaleData.TxPostData parsedPostData = gson.fromJson(postBody, LocaleData.TxPostData.class);
-        assertThat(parsedPostData.data.keySet()).containsExactly("tx_test_key");
+        assertThat(parsedPostData.data.keySet()).containsExactly("tx_test_key", "tx_plural_test_key").inOrder();
         assertThat(parsedPostData.data.get("tx_test_key").string).isEqualTo("test ελ");
+        assertThat(parsedPostData.data.get("tx_plural_test_key").string).isEqualTo("{cnt, plural, one {αυτοκίνητο} other {αυτοκίνητα}}");
     }
 
     @Test

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
@@ -39,6 +39,22 @@ public class StringXMLConverterTest {
                     "    <string name=\"key1\">This\\n is\n" +
                     "    a test</string>\n" +
                     "</resources>";
+    private static final String stringsXMLPlurals =
+            "<resources>\n" +
+                    "    <plurals name=\"plural_test\">\n" +
+                    "        <item quantity=\"zero\">zero</item>\n" +
+                    "        <item quantity=\"one\">one</item>\n" +
+                    "        <item quantity=\"two\">two</item>\n" +
+                    "        <item quantity=\"few\">few</item>\n" +
+                    "        <item quantity=\"many\">many</item>\n" +
+                    "        <item quantity=\"other\">other</item>\n" +
+                    "    </plurals>\n" +
+                    "\n" +
+                    "    <plurals name=\"plural_test2\">\n" +
+                    "        <item quantity=\"other\">other2</item>\n" +
+                    "        <item quantity=\"one\">one2</item>\n" +
+                    "    </plurals>\n" +
+                    "</resources>";
 
     static Document getXML(String string) {
         SAXBuilder builder = new SAXBuilder();
@@ -62,6 +78,10 @@ public class StringXMLConverterTest {
 
     static Document getXMLNewLine() {
         return getXML(stringsXMLNewline);
+    }
+
+    static Document getPluralsXML() {
+        return getXML(stringsXMLPlurals);
     }
 
     @Before
@@ -127,4 +147,18 @@ public class StringXMLConverterTest {
 //        assertThat(stringMap.keySet()).containsExactly("key1").inOrder();
 //        assertThat(stringMap.get("key1").string).isEqualTo("This\n is a test");
 //    }
+
+    @Test
+    public void testProcess_pluralsXMLNormal() {
+        Document document = getPluralsXML();
+        try {
+            converter.process(document, stringMap);
+        } catch (JDOMException | StringXMLConverter.XMLConverterException e) {
+            e.printStackTrace();
+        }
+
+        assertThat(stringMap.keySet()).containsExactly("plural_test", "plural_test2").inOrder();
+        assertThat(stringMap.get("plural_test").string).isEqualTo("{cnt, plural, zero {zero} one {one} two {two} few {few} many {many} other {other}}");
+        assertThat(stringMap.get("plural_test2").string).isEqualTo("{cnt, plural, one {one2} other {other2}}");
+    }
 }

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
@@ -1,18 +1,21 @@
 package com.transifex.clitool;
 
 import com.transifex.common.LocaleData;
+import com.transifex.common.Plurals;
 
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.LinkedHashMap;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class StringXMLConverterTest {
 
@@ -55,6 +58,13 @@ public class StringXMLConverterTest {
                     "        <item quantity=\"one\">one2</item>\n" +
                     "    </plurals>\n" +
                     "</resources>";
+    private static final String stringsXMLPluralsOtherNotSpecified =
+            "<resources>\n" +
+                    "    <plurals name=\"plural_test\">\n" +
+                    "        <item quantity=\"one\">one</item>\n" +
+                    "    </plurals>\n" +
+                    "\n" +
+                    "</resources>";
 
     static Document getXML(String string) {
         SAXBuilder builder = new SAXBuilder();
@@ -82,6 +92,10 @@ public class StringXMLConverterTest {
 
     static Document getPluralsXML() {
         return getXML(stringsXMLPlurals);
+    }
+
+    static Document getPluralsXMLOtherNotSpecified() {
+        return getXML(stringsXMLPluralsOtherNotSpecified);
     }
 
     @Before
@@ -160,5 +174,18 @@ public class StringXMLConverterTest {
         assertThat(stringMap.keySet()).containsExactly("plural_test", "plural_test2").inOrder();
         assertThat(stringMap.get("plural_test").string).isEqualTo("{cnt, plural, zero {zero} one {one} two {two} few {few} many {many} other {other}}");
         assertThat(stringMap.get("plural_test2").string).isEqualTo("{cnt, plural, one {one2} other {other2}}");
+    }
+
+    @Test
+    public void testProcess_pluralsXMLOtherNotSpecified_throwException() {
+        Document document = getPluralsXMLOtherNotSpecified();
+
+        assertThrows(StringXMLConverter.XMLConverterException.class, new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        converter.process(document, stringMap);
+                    }
+                }
+        );
     }
 }

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -134,7 +134,28 @@ public class LocaleData {
         public int skipped;
         public int deleted;
         public int failed;
-        public String[] errors;
+        public Error[] errors;
+
+        public boolean isSuccessful() {
+            return errors == null || errors.length == 0;
+        }
+
+        public static class Error {
+            public int status;
+            public String code;
+            public String title;
+            public String detail;
+
+            @Override
+            public String toString() {
+                return "Error{" +
+                        "status=" + status +
+                        ", code='" + code + '\'' +
+                        ", title='" + title + '\'' +
+                        ", detail='" + detail + '\'' +
+                        '}';
+            }
+        }
     }
 
     //endregion

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/Plurals.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/Plurals.java
@@ -1,0 +1,247 @@
+package com.transifex.common;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringDef;
+
+/**
+ * An object representation of Android's
+ * <a href="https://developer.android.com/guide/topics/resources/string-resource#Plurals">plurals</a>.
+ *
+ */
+public class Plurals {
+
+    /**
+     * A tag that represents the plural type. Can be  {@link #ZERO}, {@link #ONE}, {@link #TWO},
+     * {@link #FEW}, {@link #MANY}, {@link #OTHER}.
+     */
+    @StringDef({PluralType.ZERO, PluralType.ONE, PluralType.TWO, PluralType.FEW, PluralType.MANY, PluralType.OTHER})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface PluralType {
+        String ZERO = "zero";
+        String ONE = "one";
+        String TWO = "two";
+        String FEW = "few";
+        String MANY = "many";
+        String OTHER = "other";
+    }
+
+    private static final Pattern pattern = Pattern.compile("(zero|one|two|few|many|other)\\s*\\{([^}]*)\\}");
+
+    public final String zero;
+    public final String one;
+    public final String two;
+    public final String few;
+    public final String many;
+    public final String other;
+
+    Plurals(@Nullable String zero, @Nullable String one, @Nullable String two,
+            @Nullable String few, @Nullable String many, @Nullable String other) {
+        this.zero = zero;
+        this.one = one;
+        this.two = two;
+        this.few = few;
+        this.many = many;
+        this.other = other;
+    }
+
+    /**
+     * Returns the plural string for the provided plural type.
+     *
+     * @param pluralType The plural type of the string.
+     *
+     * @return The plural string for the provided plural type; the value will be <code>null</code>
+     * if no string exists for the provided plural
+     */
+    public @Nullable String getPlural(@NonNull @PluralType String pluralType) {
+        switch (pluralType) {
+            case PluralType.ZERO:
+                return  zero;
+            case PluralType.ONE:
+                return one;
+            case PluralType.TWO:
+                return two;
+            case PluralType.FEW:
+                return few;
+            case PluralType.MANY:
+                return many;
+            case PluralType.OTHER:
+                return other;
+            default:
+                throw new Builder.NonSupportedPluralTypeException("Plural type '" + pluralType + "' is not supported");
+        }
+    }
+
+    /**
+     * Returns the object as a string in ICU format.
+     */
+    public @NonNull String toICUString() {
+        StringBuilder sb = new StringBuilder("{cnt, plural,");
+        if (zero != null) {
+            appendPlural(sb, PluralType.ZERO, zero);
+        }
+        if (one != null) {
+            appendPlural(sb, PluralType.ONE, one);
+        }
+        if (two != null) {
+            appendPlural(sb, PluralType.TWO, two);
+        }
+        if (few != null) {
+            appendPlural(sb, PluralType.FEW, few);
+        }
+        if (many != null) {
+            appendPlural(sb, PluralType.MANY, many);
+        }
+        if (other != null) {
+            appendPlural(sb, PluralType.OTHER, other);
+        }
+        sb.append("}");
+
+        return sb.toString();
+    }
+
+    /**
+     * Parses the provided ICU string and creates a new Plurals object.
+     *
+     * @param icuString The ICU string to parse.
+     *
+     * @return Returns a {@link Plurals} object if parsing was successful; <code>null</code>
+     * otherwise
+     */
+    public static @Nullable
+    Plurals fromICUString(@NonNull String icuString) {
+        Matcher matcher = pattern.matcher(icuString);
+        Builder sb = new Builder();
+
+        while (matcher.find()) {
+            String pluralType = matcher.group(1);
+            String string = matcher.group(2);
+            try {
+                sb.setPlural(pluralType, string);
+            }
+            catch (Builder.NonSupportedPluralTypeException e) {
+                return null;
+            }
+        }
+
+        return sb.buildString();
+    }
+
+    private static void appendPlural(@NonNull StringBuilder sb, @NonNull @PluralType String pluralType, @NonNull String string) {
+        sb.append(" ").append(pluralType).append(" {").append(string).append("}");
+    }
+
+    @Override
+    public String toString() {
+        return "Plurals{" +
+                "zero='" + zero + '\'' +
+                ", one='" + one + '\'' +
+                ", two='" + two + '\'' +
+                ", few='" + few + '\'' +
+                ", many='" + many + '\'' +
+                ", other='" + other + '\'' +
+                '}';
+    }
+
+    /**
+     * A class for building a {@link Plurals} object.
+     */
+    public static class Builder {
+
+        public static class NonSupportedPluralTypeException extends RuntimeException{
+            public NonSupportedPluralTypeException() {
+                super();
+            }
+
+            public NonSupportedPluralTypeException(String message) {
+                super(message);
+            }
+        }
+
+        private String zero;
+        private String one;
+        private String two;
+        private String few;
+        private String many;
+        private String other;
+
+        public Builder setZero(@Nullable String zero) {
+            this.zero = zero;
+            return this;
+        }
+
+        public Builder setOne(@Nullable String one) {
+            this.one = one;
+            return this;
+        }
+
+        public Builder setTwo(@Nullable String two) {
+            this.two = two;
+            return this;
+        }
+
+        public Builder setFew(@Nullable String few) {
+            this.few = few;
+            return this;
+        }
+
+        public Builder setMany(String many) {
+            this.many = many;
+            return this;
+        }
+
+        public Builder setOther(@Nullable String other) {
+            this.other = other;
+            return this;
+        }
+
+        /**
+         * Assigns the given string to the given plural type.
+         *
+         * @param pluralType The plural type of the string.
+         * @param string The string to set.
+         *
+         * @throws NonSupportedPluralTypeException if <code>pluralType</code>'s value is not one of
+         * {@link PluralType} ones.
+         */
+        public Builder setPlural(@NonNull @PluralType String pluralType, @Nullable String string) {
+            switch (pluralType) {
+                case PluralType.ZERO:
+                    setZero(string);
+                    break;
+                case PluralType.ONE:
+                    setOne(string);
+                    break;
+                case PluralType.TWO:
+                    setTwo(string);
+                    break;
+                case PluralType.FEW:
+                    setFew(string);
+                    break;
+                case PluralType.MANY:
+                    setMany(string);
+                    break;
+                case PluralType.OTHER:
+                    setOther(string);
+                    break;
+                default:
+                    throw new NonSupportedPluralTypeException("Plural type '" + pluralType + "' is not supported");
+            }
+
+            return this;
+        }
+
+        /**
+         * Builds a <code>Plurals</code> object with the current configuration.
+         */
+        public @NonNull
+        Plurals buildString() {
+            return new Plurals(zero, one, two, few, many, other);
+        }
+    }
+}

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
@@ -156,4 +156,27 @@ public class LocaleDataTest {
         assertThat(copyOfA).isEqualTo(sameAsA);
     }
 
+    @Test
+    public void testTxPostResponseDataIsSuccessful_noErrors_successful() {
+        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
+
+        assertThat(responseData.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void testTxPostResponseDataIsSuccessful_emptyErrorArray_successful() {
+        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
+        responseData.errors = new LocaleData.TxPostResponseData.Error[0];
+
+        assertThat(responseData.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void testTxPostResponseDataIsSuccessful_errors_notSuccessful() {
+        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
+        responseData.errors = new LocaleData.TxPostResponseData.Error[]{new LocaleData.TxPostResponseData.Error()};
+
+        assertThat(responseData.isSuccessful()).isFalse();
+    }
+
 }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/PluralsTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/PluralsTest.java
@@ -37,17 +37,11 @@ public class PluralsTest {
     }
 
     @Test
-    public void testFromICUString_emptyString_returnEmptyPlurals() {
+    public void testFromICUString_emptyString_returnNull() {
         String icuString = "";
         Plurals plurals = Plurals.fromICUString(icuString);
 
-        assertThat(plurals).isNotNull();
-        assertThat(plurals.zero).isNull();
-        assertThat(plurals.one).isNull();
-        assertThat(plurals.two).isNull();
-        assertThat(plurals.few).isNull();
-        assertThat(plurals.many).isNull();
-        assertThat(plurals.other).isNull();
+        assertThat(plurals).isNull();
     }
 
     @Test
@@ -70,26 +64,38 @@ public class PluralsTest {
     }
 
     @Test
+    public void testBuilder_otherNotSpecified_throwException() {
+        Plurals.Builder sb = new Plurals.Builder();
+
+        assertThrows(Plurals.InvalidPluralsConfiguration.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                sb.buildString();
+            }
+        });
+    }
+
+    @Test
     public void testBuilderSetPlural_normal() {
         Plurals.Builder sb = new Plurals.Builder();
-        sb.setPlural(Plurals.PluralType.FEW, "test");
+        sb.setPlural(Plurals.PluralType.OTHER, "other!");
         Plurals plurals = sb.buildString();
 
         assertThat(plurals.zero).isNull();
         assertThat(plurals.one).isNull();
         assertThat(plurals.two).isNull();
-        assertThat(plurals.few).isEqualTo("test");
+        assertThat(plurals.few).isNull();
         assertThat(plurals.many).isNull();
-        assertThat(plurals.other).isNull();
+        assertThat(plurals.other).isEqualTo("other!");
     }
 
     @Test
     public void testBuilderSetPlural_nonSupportedPluralType_throwException() {
         Plurals.Builder sb = new Plurals.Builder();
 
-        assertThrows(Plurals.Builder.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
+        assertThrows(Plurals.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
             @Override
-            public void run() {
+            public void run() throws Throwable {
                 sb.setPlural("Invalid plural type", "test");
             }
         });
@@ -109,16 +115,6 @@ public class PluralsTest {
         String icuString = plurals.toICUString();
 
         assertThat(icuString).isEqualTo("{cnt, plural, zero {none} one {just one} two {just two} few {a few} many {many} other {other!}}");
-    }
-
-    @Test
-    public void testToICUString_empty() {
-        Plurals.Builder sb = new Plurals.Builder();
-        Plurals plurals = sb.buildString();
-
-        String icuString = plurals.toICUString();
-
-        assertThat(icuString).isEqualTo("{cnt, plural,}");
     }
 
     @Test
@@ -151,9 +147,9 @@ public class PluralsTest {
                 .setOther("other!");
         Plurals plurals = sb.buildString();
 
-        assertThrows(Plurals.Builder.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
+        assertThrows(Plurals.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
             @Override
-            public void run() {
+            public void run() throws Throwable {
                 plurals.getPlural("Invalid plural type");
             }
         });

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/PluralsTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/PluralsTest.java
@@ -1,0 +1,162 @@
+package com.transifex.common;
+
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class PluralsTest {
+
+    @Test
+    public void testFromICUString_normal() {
+        String icuString = "{???, plural, zero {task0} one {task} two {task2} few {tasks} many {tasksss} other {tasks}}";
+        Plurals plurals = Plurals.fromICUString(icuString);
+
+        assertThat(plurals).isNotNull();
+        assertThat(plurals.zero).isEqualTo("task0");
+        assertThat(plurals.one).isEqualTo("task");
+        assertThat(plurals.two).isEqualTo("task2");
+        assertThat(plurals.few).isEqualTo("tasks");
+        assertThat(plurals.many).isEqualTo("tasksss");
+        assertThat(plurals.other).isEqualTo("tasks");
+    }
+
+    @Test
+    public void testFromICUString_oneIncorrectPluralStyle_parseRestOfThem() {
+        String icuString = "{???, plural, WRONG {task} other {tasks}}";
+        Plurals plurals = Plurals.fromICUString(icuString);
+
+        assertThat(plurals).isNotNull();
+        assertThat(plurals.zero).isNull();
+        assertThat(plurals.one).isNull();
+        assertThat(plurals.two).isNull();
+        assertThat(plurals.few).isNull();
+        assertThat(plurals.many).isNull();
+        assertThat(plurals.other).isEqualTo("tasks");
+    }
+
+    @Test
+    public void testFromICUString_emptyString_returnEmptyPlurals() {
+        String icuString = "";
+        Plurals plurals = Plurals.fromICUString(icuString);
+
+        assertThat(plurals).isNotNull();
+        assertThat(plurals.zero).isNull();
+        assertThat(plurals.one).isNull();
+        assertThat(plurals.two).isNull();
+        assertThat(plurals.few).isNull();
+        assertThat(plurals.many).isNull();
+        assertThat(plurals.other).isNull();
+    }
+
+    @Test
+    public void testBuilder_normal() {
+        Plurals.Builder sb = new Plurals.Builder();
+        sb.setZero("none")
+                .setOne("just one")
+                .setTwo("just two")
+                .setFew("a few")
+                .setMany("many")
+                .setOther("other!");
+        Plurals plurals = sb.buildString();
+
+        assertThat(plurals.zero).isEqualTo("none");
+        assertThat(plurals.one).isEqualTo("just one");
+        assertThat(plurals.two).isEqualTo("just two");
+        assertThat(plurals.few).isEqualTo("a few");
+        assertThat(plurals.many).isEqualTo("many");
+        assertThat(plurals.other).isEqualTo("other!");
+    }
+
+    @Test
+    public void testBuilderSetPlural_normal() {
+        Plurals.Builder sb = new Plurals.Builder();
+        sb.setPlural(Plurals.PluralType.FEW, "test");
+        Plurals plurals = sb.buildString();
+
+        assertThat(plurals.zero).isNull();
+        assertThat(plurals.one).isNull();
+        assertThat(plurals.two).isNull();
+        assertThat(plurals.few).isEqualTo("test");
+        assertThat(plurals.many).isNull();
+        assertThat(plurals.other).isNull();
+    }
+
+    @Test
+    public void testBuilderSetPlural_nonSupportedPluralType_throwException() {
+        Plurals.Builder sb = new Plurals.Builder();
+
+        assertThrows(Plurals.Builder.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                sb.setPlural("Invalid plural type", "test");
+            }
+        });
+    }
+
+    @Test
+    public void testToICUString_normal() {
+        Plurals.Builder sb = new Plurals.Builder();
+        sb.setZero("none")
+                .setOne("just one")
+                .setTwo("just two")
+                .setFew("a few")
+                .setMany("many")
+                .setOther("other!");
+        Plurals plurals = sb.buildString();
+        
+        String icuString = plurals.toICUString();
+
+        assertThat(icuString).isEqualTo("{cnt, plural, zero {none} one {just one} two {just two} few {a few} many {many} other {other!}}");
+    }
+
+    @Test
+    public void testToICUString_empty() {
+        Plurals.Builder sb = new Plurals.Builder();
+        Plurals plurals = sb.buildString();
+
+        String icuString = plurals.toICUString();
+
+        assertThat(icuString).isEqualTo("{cnt, plural,}");
+    }
+
+    @Test
+    public void testGetPlural_normal() {
+        Plurals.Builder sb = new Plurals.Builder();
+        sb.setZero("none")
+                .setOne("just one")
+                .setTwo("just two")
+                .setFew("a few")
+                .setMany("many")
+                .setOther("other!");
+        Plurals plurals = sb.buildString();
+
+        assertThat(plurals.getPlural(Plurals.PluralType.ZERO)).isEqualTo("none");
+        assertThat(plurals.getPlural(Plurals.PluralType.ONE)).isEqualTo("just one");
+        assertThat(plurals.getPlural(Plurals.PluralType.TWO)).isEqualTo("just two");
+        assertThat(plurals.getPlural(Plurals.PluralType.FEW)).isEqualTo("a few");
+        assertThat(plurals.getPlural(Plurals.PluralType.MANY)).isEqualTo("many");
+        assertThat(plurals.getPlural(Plurals.PluralType.OTHER)).isEqualTo("other!");
+    }
+
+    @Test
+    public void testGetPlural_nonSupportedPluralType_throwException() {
+        Plurals.Builder sb = new Plurals.Builder();
+        sb.setZero("none")
+                .setOne("just one")
+                .setTwo("just two")
+                .setFew("a few")
+                .setMany("many")
+                .setOther("other!");
+        Plurals plurals = sb.buildString();
+
+        assertThrows(Plurals.Builder.NonSupportedPluralTypeException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                plurals.getPlural("Invalid plural type");
+            }
+        });
+
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/PluralsTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/PluralsTest.java
@@ -15,6 +15,9 @@ import static com.google.common.truth.Truth.assertThat;
 @SmallTest
 public class PluralsTest {
 
+    // The following test is copied from the respective unit test. We just want to make sure the
+    // internal regex patter compiles correctly on a device.
+
     @Test
     public void testFromICUString_oneIncorrectPluralStyle_parseRestOfThem() {
         String icuString = "{???, plural, WRONG {task} other {tasks}}";

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/PluralsTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/PluralsTest.java
@@ -1,0 +1,31 @@
+package com.transifex.txnative;
+
+import com.transifex.common.Plurals;
+
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class PluralsTest {
+
+    @Test
+    public void testFromICUString_oneIncorrectPluralStyle_parseRestOfThem() {
+        String icuString = "{???, plural, WRONG {task} other {tasks}}";
+        Plurals plurals = Plurals.fromICUString(icuString);
+
+        assertThat(plurals).isNotNull();
+        assertThat(plurals.zero).isNull();
+        assertThat(plurals.one).isNull();
+        assertThat(plurals.two).isNull();
+        assertThat(plurals.few).isNull();
+        assertThat(plurals.many).isNull();
+        assertThat(plurals.other).isEqualTo("tasks");
+    }
+}

--- a/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxStandardCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/androidTest/java/com/transifex/txnative/cache/TxStandardCacheTest.java
@@ -171,7 +171,7 @@ public class TxStandardCacheTest {
         cache.update(getUpdatedTranslationMap());
 
         // Make another cache after having the translations saved on disk by the previous cache
-        TxCache secondRunCache = TxStandardCache.getCache(appContext, TxUpdateFilterCache.UPDATE_USING_TRANSLATED, null);
+        TxCache secondRunCache = TxStandardCache.getCache(appContext, TxUpdateFilterCache.TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED, null);
         assertThat(changeToSameThreadExecutor(secondRunCache)).isTrue();
 
         assertThat(secondRunCache.get()).isEqualTo(getTranslationsForUpdateUsingTranslatedGroundTruth());

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -83,7 +83,7 @@ public class NativeCore {
         // Check that the "R.plurals.tx_plurals" plurals resource declared in the lib's "strings.xml"
         // file is accessible.
         try {
-            mContext.getResources().getResourceEntryName(R.plurals.tx_plurals);
+            mContext.getResources().getResourceEntryName(R.plurals.__tx_plurals);
         }
         catch (Resources.NotFoundException e) {
             throw new RuntimeException("The strings resources of txnative are not bundled in the app.");
@@ -324,7 +324,7 @@ public class NativeCore {
         }
 
         // Use Android's localization system to get the correct plural type for the given quantity
-        String pluralType = txResources.getOriginalQuantityText(R.plurals.tx_plurals, quantity).toString();
+        String pluralType = txResources.getOriginalQuantityText(R.plurals.__tx_plurals, quantity).toString();
 
         // Get plural string from Plurals
         String plural = plurals.getPlural(pluralType);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -285,7 +285,7 @@ public class NativeCore {
         }
 
         // No ICU string found in cache or no quantity string was rendered
-        if (quantityString == null) {
+        if (TextUtils.isEmpty(quantityString)) {
             // Get source string using source locale's plural rules
             CharSequence sourceString = mSourceLocaleResources.getQuantityText(id, quantity);
             return mMissingPolicy.getQuantityString(sourceString, id, quantity,

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -106,10 +106,6 @@ public class TxNative {
         sNativeCore.setSupportSpannable(enabled);
     }
 
-    //TODO: update the documentation, when local cache is implemented, to explain when these
-    // translations affect the app. Currently, they affect it instantly but the activity has
-    // to be reloaded after they have been fetched.
-
     /**
      * Fetches the translations from CDS and updates the cache.
      * <p>

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Native;
 import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.PluralsRes;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 
@@ -70,18 +71,7 @@ public class TxResources extends Resources {
     @NonNull
     @Override
     public CharSequence getQuantityText(@StringRes int id, int quantity) throws NotFoundException {
-        CharSequence originalString = mResources.getQuantityText(id, quantity);
-
-        if (isAndroidStringResource(id)) {
-            return originalString;
-        }
-
-        if (quantity == 1) {
-            return "test: " + originalString;
-        }
-        else {
-            return  "tests " + originalString;
-        }
+        return mNativeCore.translateQuantityString(this, id, quantity);
     }
 
     @NonNull
@@ -113,7 +103,7 @@ public class TxResources extends Resources {
     //region Interface
 
     /**
-     * Checks if the provided string resource id belongs to Android's resource package.
+     * Checks if the provided string or plurals resource id belongs to Android's resource package.
      *
      * @param id The string resource ID to check.
      *
@@ -121,17 +111,22 @@ public class TxResources extends Resources {
      *
      * @throws NotFoundException Throws NotFoundException if the given ID does not exist.
      */
-    boolean isAndroidStringResource(@StringRes int id) {
+    boolean isAndroidStringResource(@StringRes @PluralsRes int id) throws NotFoundException {
         String resourcePackageName = mResources.getResourcePackageName(id);
         return resourcePackageName.equals("android");
     }
 
-    @NonNull CharSequence getOriginalText(@StringRes int id) {
+    @NonNull CharSequence getOriginalText(@StringRes int id) throws NotFoundException {
         return mResources.getText(id);
     }
 
     @Nullable CharSequence getOriginalText(@StringRes int id, @Nullable CharSequence def) {
         return mResources.getText(id, def);
+    }
+
+    @NonNull CharSequence getOriginalQuantityText(@PluralsRes int id, int quantity)
+            throws NotFoundException {
+        return mResources.getQuantityText(id, quantity);
     }
 
     //endregion Interface

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
@@ -77,25 +77,13 @@ public class TxResources extends Resources {
     @NonNull
     @Override
     public CharSequence[] getTextArray(@StringRes int id) throws NotFoundException {
-        CharSequence[] originalTextArray = mResources.getTextArray(id);
-
-        if (isAndroidStringResource(id)) {
-            return originalTextArray;
-        }
-
-        return new CharSequence[]{"test1", "test2"};
+        return mResources.getTextArray(id);
     }
 
     @NonNull
     @Override
     public String[] getStringArray(@StringRes int id) throws NotFoundException {
-        String[] originalStringArray = mResources.getStringArray(id);
-
-        if (isAndroidStringResource(id)) {
-            return originalStringArray;
-        }
-
-        return new String[]{"test1", "test2"};
+        return mResources.getStringArray(id);
     }
 
     //endregion Overrides

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
@@ -119,7 +119,7 @@ public class Utils {
      * <code>`strings.xml`</code> file.
      */
     @NonNull
-    public static Resources getDefaultLanguageResources(@NonNull Context context) {
+    public static Resources getDefaultLocaleResources(@NonNull Context context) {
         return getLocalizedResources(context, new Locale(""));
     }
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxStandardCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxStandardCache.java
@@ -29,7 +29,7 @@ public class TxStandardCache {
      * @param context The app's context.
      * @param updatePolicy The update policy to be used when initializing the internal memory
      *                     cache with the stored contents from disk. If set to <code>null</code>,
-     *                     {@link TxUpdateFilterCache#REPLACE_ALL} is used.
+     *                     {@link TxUpdateFilterCache.TxCacheUpdatePolicy#REPLACE_ALL REPLACE_ALL} is used.
      * @param cachedTranslationsDirectory The directory where the cache will store new translations
      *                                    when available and read translations from when initialized.
      *                                    If set to <code>null</code> it uses a "txnative" folder in
@@ -42,7 +42,7 @@ public class TxStandardCache {
                                    @Nullable File cachedTranslationsDirectory) {
 
         if (updatePolicy == null) {
-            updatePolicy = TxUpdateFilterCache.REPLACE_ALL;
+            updatePolicy = TxUpdateFilterCache.TxCacheUpdatePolicy.REPLACE_ALL;
         }
         if (cachedTranslationsDirectory == null) {
             cachedTranslationsDirectory = new File(context.getCacheDir() + File.separator

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
@@ -69,19 +69,20 @@ public class TxUpdateFilterCache extends TxDecoratorCache {
      * </ul>
      *
      */
-    @IntDef({REPLACE_ALL, UPDATE_USING_TRANSLATED})
+    @IntDef({TxCacheUpdatePolicy.REPLACE_ALL, TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED})
     @Retention(RetentionPolicy.SOURCE)
-    public @interface TxCacheUpdatePolicy {}
+    public @interface TxCacheUpdatePolicy {
+        /**
+         * Discards the existing cache entries completely and populates the cache with the new entries,
+         * even if they contain empty translations.
+         */
+        int REPLACE_ALL = 0;
 
-    /**
-     * Discards the existing cache entries completely and populates the cache with the new entries,
-     * even if they contain empty translations.
-     */
-    public static final int REPLACE_ALL = 0;
-    /**
-     * Updates the existing cache with the new entries that have a non-empty translation.
-     */
-    public static final int UPDATE_USING_TRANSLATED = 1;
+        /**
+         * Updates the existing cache with the new entries that have a non-empty translation.
+         */
+        int UPDATE_USING_TRANSLATED = 1;
+    }
 
     private final @TxCacheUpdatePolicy int mPolicy;
 
@@ -108,10 +109,10 @@ public class TxUpdateFilterCache extends TxDecoratorCache {
      */
     @Override
     public void update(@NonNull LocaleData.TranslationMap translationMap) {
-        if (mPolicy == REPLACE_ALL) {
+        if (mPolicy == TxCacheUpdatePolicy.REPLACE_ALL) {
             super.update(translationMap);
         }
-        else if (mPolicy == UPDATE_USING_TRANSLATED) {
+        else if (mPolicy == TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED) {
             // Make a copy of the internal cache's TranslationMap, in order to apply the updates there
             LocaleData.TranslationMap updatedTranslations = new LocaleData.TranslationMap(get());
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicy.java
@@ -3,6 +3,8 @@ package com.transifex.txnative.missingpolicy;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.PluralsRes;
+import androidx.annotation.StringRes;
 
 /**
  * Returns the string using Android's localization system.
@@ -29,8 +31,21 @@ public class AndroidMissingPolicy implements MissingPolicy{
      * without using TxNative functionality.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, int id,
+    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         return context.getResources().getText(id);
+    }
+
+    /**
+     * Returns a translated quantity string using Android's localization system.
+     * <p>
+     * The result is equivalent to calling {@link android.content.res.Resources#getQuantityText(int, int)}
+     * without using TxNative functionality.
+     */
+    @Override
+    @NonNull public CharSequence getQuantityString(
+            @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
+            @NonNull String resourceName, @NonNull String locale) {
+        return context.getResources().getQuantityText(id, quantity);
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicy.java
@@ -1,6 +1,8 @@
 package com.transifex.txnative.missingpolicy;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.PluralsRes;
+import androidx.annotation.StringRes;
 
 /**
  * Combines multiple policies to create a complex result.
@@ -27,7 +29,7 @@ public class CompositeMissingPolicy implements MissingPolicy{
      * Returns a string after it has been fed to all of the provided policies from first to last.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, int id,
+    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         CharSequence string = sourceString;
         for (MissingPolicy policy : mMissingPolicies) {
@@ -35,5 +37,21 @@ public class CompositeMissingPolicy implements MissingPolicy{
         }
 
         return  string;
+    }
+
+    /**
+     * Returns a quantity string after it has been fed to all of the provided policies from first
+     * to last.
+     */
+    @Override
+    @NonNull public CharSequence getQuantityString(
+            @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
+            @NonNull String resourceName, @NonNull String locale) {
+        CharSequence quantityString = sourceQuantityString;
+        for (MissingPolicy policy : mMissingPolicies) {
+            quantityString = policy.getQuantityString(quantityString, id, quantity, resourceName, locale);
+        }
+
+        return  quantityString;
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/MissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/MissingPolicy.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 import com.transifex.txnative.LocaleState;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
 
 /**
@@ -30,4 +31,27 @@ public interface MissingPolicy {
      */
     @NonNull CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
                               @NonNull String resourceName, @NonNull String locale);
+
+    /**
+     * Return a quantity string as a translation based on the given source quantity string and
+     * quantity.
+     * <p>
+     * Classes that implement this interface may choose to return anything relevant to the given
+     * source string or not, based on their custom policy.
+     *
+     * @param sourceQuantityString The source string having grammatically correct pluralization for
+     *                             the given quantity.
+     * @param id The plurals resource identifier as defined by
+     * {@link Resources#getIdentifier(String, String, String)}.
+     * @param quantity The number used to get the correct string for the current language's plural
+     *                 rules.
+     * @param resourceName The entry name of the plurals resource as defined by
+     * {@link Resources#getResourceEntryName(int)}.
+     * @param locale The current locale as returned by {@link LocaleState#getResolvedLocale()}.
+     *
+     * @return The translated string.
+     */
+    @NonNull CharSequence getQuantityString(@NonNull CharSequence sourceQuantityString,
+                                            @PluralsRes int id, int quantity,
+                                            @NonNull String resourceName, @NonNull String locale);
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/SourceStringPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/SourceStringPolicy.java
@@ -1,6 +1,8 @@
 package com.transifex.txnative.missingpolicy;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.PluralsRes;
+import androidx.annotation.StringRes;
 
 /**
  * Returns the source string when the translation string is missing.
@@ -9,14 +11,20 @@ public class SourceStringPolicy implements MissingPolicy {
 
     /**
      * Return the source string as the translation string.
-     *
-     * @param sourceString The source string.
-     *
-     * @return The source string.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, int id,
+    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         return sourceString;
+    }
+
+    /**
+     * Returns the source quantity string as the translation quantity string.
+     */
+    @Override
+    @NonNull public CharSequence getQuantityString(
+            @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
+            @NonNull String resourceName, @NonNull String locale) {
+        return sourceQuantityString;
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
@@ -8,6 +8,8 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.PluralsRes;
+import androidx.annotation.StringRes;
 
 /**
  * Wraps the source string with a custom format.
@@ -48,11 +50,12 @@ public class WrappedStringPolicy implements MissingPolicy{
     }
 
     /**
-     * Return a string that wraps the source string.
+     * Wraps the provided sourceString with the <code>start</code> and <code>end</code> strings.
+     * <p>
+     * If sourceString is {@link Spanned}, a {@link SpannedString} containing the same spans is
+     * returned.
      */
-    @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, int id,
-                                     @NonNull String resourceName, @NonNull String locale) {
+    @NonNull CharSequence wrapString(@NonNull CharSequence sourceString) {
         if (TextUtils.isEmpty(start) && TextUtils.isEmpty(end)) {
             return sourceString;
         }
@@ -80,5 +83,24 @@ public class WrappedStringPolicy implements MissingPolicy{
             }
             return sb.toString();
         }
+    }
+
+    /**
+     * Returns a wrapped string.
+     */
+    @Override
+    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
+                                     @NonNull String resourceName, @NonNull String locale) {
+        return wrapString(sourceString);
+    }
+
+    /**
+     * Returns a wrapped quantity string.
+     */
+    @Override
+    @NonNull public CharSequence getQuantityString(
+            @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
+            @NonNull String resourceName, @NonNull String locale) {
+        return wrapString(sourceQuantityString);
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
+++ b/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Hide the resources from library users -->
+    <public />
+
     <!-- Plurals resource used by txnative to get the correct plural rule for a locale -->
-    <plurals name="tx_plurals">
+    <plurals name="__tx_plurals">
         <item quantity="zero">zero</item>
         <item quantity="one">one</item>
         <item quantity="two">two</item>

--- a/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
+++ b/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="tx_plurals">
+        <item quantity="zero">zero</item>
+        <item quantity="one">one</item>
+        <item quantity="two">two</item>
+        <item quantity="few">few</item>
+        <item quantity="many">many</item>
+        <item quantity="other">other</item>
+    </plurals>
+</resources>

--- a/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
+++ b/TransifexNativeSDK/txsdk/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals resource used by txnative to get the correct plural rule for a locale -->
     <plurals name="tx_plurals">
         <item quantity="zero">zero</item>
         <item quantity="one">one</item>

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
@@ -46,34 +46,7 @@ public class NativeCoreTest {
     private TxMemoryCache getElMemoryCache() {
         HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
         dic2.put("tx_test_key", new LocaleData.StringInfo("test ελ tx"));
-        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
-
-        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
-        translationMap.put("el", elStrings);
-
-        TxMemoryCache memoryCache = new TxMemoryCache();
-        memoryCache.update(translationMap);
-
-        return memoryCache;
-    }
-
-    private TxMemoryCache getElSpanMemoryCache() {
-        HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
-        dic2.put("tx_test_key", new LocaleData.StringInfo("this is <b>bold</b>"));
-        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
-
-        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
-        translationMap.put("el", elStrings);
-
-        TxMemoryCache memoryCache = new TxMemoryCache();
-        memoryCache.update(translationMap);
-
-        return memoryCache;
-    }
-
-    private TxMemoryCache getElHTMLEscapedMemoryCache() {
-        HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
-        dic2.put("tx_test_key", new LocaleData.StringInfo("this is &lt;b>bold&lt;/b>"));
+        dic2.put("tx_plural_test_key", new LocaleData.StringInfo("{cnt, plural, one {αυτοκίνητο tx} other {αυτοκίνητα tx}}"));
         LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
 
         LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
@@ -94,9 +67,20 @@ public class NativeCoreTest {
         return memoryCache;
     }
 
+    private static final String STRING_WITHOUT_TAGS = "this is not bold";
+    private static final String STRING_WITH_TAGS = "this is <b>bold</b>";
+    private static final String STRING_WITH_TAGS_HTML_ESCAPED = "this is &lt;b>bold&lt;/b>";
+
+    private static final String ICU_STRING = "{cnt, plural, zero {zero} one {this is one} two {just two} few {just a few} many {a lot!} other {others!}}";
+    private static final String ICU_STRING_SIMPLE = "{cnt, plural, one {this is one} other {others!}}";
+    private static final String ICU_STRING_NOOTHERs = "{cnt, plural, one {this is one}}";
+    private static final String ICU_STRING_EMPTY = "{cnt, plural, }";
+
+    // region translate
+
     @Test
     @Config(qualifiers = "en")
-    public void testTranslate_sourceLocale() {
+    public void testTranslate_androidUsesSourceLocale() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -112,7 +96,7 @@ public class NativeCoreTest {
 
     @Test
     @Config(qualifiers = "el-rGR")
-    public void testTranslate_supportedLocale() {
+    public void testTranslate_androidUsesSupportedLocale() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -128,7 +112,7 @@ public class NativeCoreTest {
 
     @Test
     @Config(qualifiers = "es-rES")
-    public void testTranslate_defaultMissingPolicy_unsupportedLocale() {
+    public void testTranslateWithDefaultMissingPolicy_androidUsesUnsupportedLocale_returnSourceString() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -143,7 +127,7 @@ public class NativeCoreTest {
     }
 
     @Test
-    public void testTranslate_idDoesNotExist() {
+    public void testTranslate_idDoesNotExist_exceptionIsThrown() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -161,7 +145,7 @@ public class NativeCoreTest {
     }
 
     @Test
-    public void testTranslateDefault_idDoesNotExist() {
+    public void testTranslateWithDefaultString_idDoesNotExist_defaultStringIsReturned() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -177,7 +161,7 @@ public class NativeCoreTest {
 
     @Test
     @Config(qualifiers = "el-rGR")
-    public void testTranslate_testMode() {
+    public void testTranslate_testMode_returnPrefixedString() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -194,7 +178,7 @@ public class NativeCoreTest {
 
     @Test
     @Config(qualifiers = "el-rGR")
-    public void testTranslate_testMode_androidResource() {
+    public void testTranslate_testModeAndUseAndroidResourceString_returnedStringNotPrefixed() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
@@ -204,25 +188,30 @@ public class NativeCoreTest {
         nativeCore.setTestMode(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence androidString = mockContext.getResources().getString(android.R.string.ok);
-        CharSequence string = nativeCore.translate(txResources, android.R.string.ok);
+        CharSequence androidString = mockContext.getResources().getString(android.R.string.cancel);
+        CharSequence string = nativeCore.translate(txResources, android.R.string.cancel);
 
         assertThat(string).isEqualTo(androidString);
     }
 
+    // endregion translate
+
+    // region spanned string
+
     @Test
-    @Config(qualifiers = "el-rGR")
-    public void testTranslate_spanSupportEnabled_spanString() {
+    @Config(qualifiers = "en")
+    public void testGetSpannedString_spanSupportEnabled_returnSpannedString() {
+        // We expect the tags to be parsed into spans
+
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
                 null);
-        TxMemoryCache elMemoryCache = getElSpanMemoryCache();
-        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxMemoryCache dummyCache = getEmptyMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
         nativeCore.setSupportSpannable(true);
-        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence string = nativeCore.translate(txResources, R.string.tx_test_key);
+        CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS);
 
         assertThat(string).isInstanceOf(Spanned.class);
 
@@ -241,18 +230,19 @@ public class NativeCoreTest {
     }
 
     @Test
-    @Config(qualifiers = "el-rGR")
-    public void testTranslate_spanSupportEnabled_HTMLEscapedString() {
+    @Config(qualifiers = "en")
+    public void testGetSpannedString_spanSupportEnabledWithHTMLEscapedString_returnSpannedString() {
+        // We expect the tags, even though they use "&lt;" instead of "<" to be parsed into spans
+
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
                 null);
-        TxMemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
-        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxMemoryCache dummyCache = getEmptyMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
         nativeCore.setSupportSpannable(true);
-        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence string = nativeCore.translate(txResources, R.string.tx_test_key);
+        CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS_HTML_ESCAPED);
 
         assertThat(string).isInstanceOf(String.class);
 
@@ -274,85 +264,367 @@ public class NativeCoreTest {
     }
 
     @Test
-    @Config(qualifiers = "el-rGR")
-    public void testTranslate_spanSupportEnabled_simpleString() {
+    @Config(qualifiers = "en")
+    public void testGetSpannedString_spanSupportEnabledWithSimpleString_returnString() {
+        // We expect to get a String object, since no tags exist in the  parsed string
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache dummyCache = getEmptyMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
+        nativeCore.setSupportSpannable(true);
+
+        CharSequence string = nativeCore.getSpannedString(STRING_WITHOUT_TAGS);
+
+        assertThat(string).isInstanceOf(String.class);
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testGetSpannedString_spanSupportDisabled_returnStringWithTags() {
+        // We expect to get a String object, because span support is disabled. The tags of the
+        // parsed string should be kept as-is.
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache dummyCache = getEmptyMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
+
+        CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS);
+
+        assertThat(string).isInstanceOf(String.class);
+
+        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
+
+        CharSequence styledPart = null;
+
+        {
+            Spanned spanned = (Spanned) string;
+            StyleSpan[] spans = spanned.getSpans(0, spanned.length(), StyleSpan.class);
+            StyleSpan span = spans[0];
+            int start = spanned.getSpanStart(span);
+            int end = spanned.getSpanEnd(span);
+            styledPart = spanned.subSequence(start, end);
+        }
+
+        assertThat(styledPart).isNotNull();
+        assertThat(styledPart.toString()).isEqualTo("bold");
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testGetSpannedString_spanSupportDisabledWithHTMLEscapedString_returnStringWithTags() {
+        // We expect to get a String object, because span support is disabled. "&lt;" should be
+        // converted to "<", so that tags exist in the returned string.
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache dummyCache = getEmptyMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
+
+        CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS_HTML_ESCAPED);
+
+        assertThat(string).isInstanceOf(String.class);
+
+        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
+
+        CharSequence styledPart = null;
+
+        {
+            Spanned spanned = (Spanned) string;
+            StyleSpan[] spans = spanned.getSpans(0, spanned.length(), StyleSpan.class);
+            StyleSpan span = spans[0];
+            int start = spanned.getSpanStart(span);
+            int end = spanned.getSpanEnd(span);
+            styledPart = spanned.subSequence(start, end);
+        }
+
+        assertThat(styledPart).isNotNull();
+        assertThat(styledPart.toString()).isEqualTo("bold");
+    }
+
+    // endregion spanned string
+
+    // region translate quantity string
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testGetLocalizedQuantityString_androidUsesEN() {
+        // https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#en
+
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
                 null);
         TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
-        nativeCore.setSupportSpannable(true);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence string = nativeCore.translate(txResources, R.string.tx_test_key);
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 20);
 
-        assertThat(string).isInstanceOf(String.class);
+        assertThat(quantityStringForZero).isEqualTo("others!");
+        assertThat(quantityStringForOne).isEqualTo("this is one");
+        assertThat(quantityStringForTwo).isEqualTo("others!");
+        assertThat(quantityStringForThree).isEqualTo("others!");
+        assertThat(quantityStringForALot).isEqualTo("others!");
     }
 
     @Test
-    @Config(qualifiers = "el-rGR")
-    public void testTranslate_spanSupportDisabled_spanString() {
+    @Config(qualifiers = "sl")
+    public void testGetLocalizedQuantityString_androidUsesSL() {
+        // https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sl
+
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
                 null);
-        TxMemoryCache elMemoryCache = getElSpanMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence string = nativeCore.translate(txResources, R.string.tx_test_key);
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING, 20);
 
-        assertThat(string).isInstanceOf(String.class);
-
-        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
-
-        CharSequence styledPart = null;
-
-        {
-            Spanned spanned = (Spanned) string;
-            StyleSpan[] spans = spanned.getSpans(0, spanned.length(), StyleSpan.class);
-            StyleSpan span = spans[0];
-            int start = spanned.getSpanStart(span);
-            int end = spanned.getSpanEnd(span);
-            styledPart = spanned.subSequence(start, end);
-        }
-
-        assertThat(styledPart).isNotNull();
-        assertThat(styledPart.toString()).isEqualTo("bold");
+        assertThat(quantityStringForZero).isEqualTo("others!");
+        assertThat(quantityStringForOne).isEqualTo("this is one");
+        assertThat(quantityStringForTwo).isEqualTo("just two");
+        assertThat(quantityStringForThree).isEqualTo("just a few");
+        assertThat(quantityStringForALot).isEqualTo("others!");
     }
 
     @Test
-    @Config(qualifiers = "el-rGR")
-    public void testTranslate_spanSupportDisabled_HTMLEscapedString() {
+    @Config(qualifiers = "sl")
+    public void testGetLocalizedQuantityString_androidUsesSLAndICUStringWithoutAllPlurals_fallbackToOthersPlural() {
+        // https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sl
+
+        // In this test, the ICU does not have "TWO" and "FEW" plurals. We expect the "OTHERS" plural
+        // to be used as fallback
+
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},
                 null);
-        TxMemoryCache elMemoryCache = getElHTMLEscapedMemoryCache();
+        TxMemoryCache elMemoryCache = getElMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        CharSequence string = nativeCore.translate(txResources, R.string.tx_test_key);
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_SIMPLE, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_SIMPLE, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_SIMPLE, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_SIMPLE, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_SIMPLE, 20);
 
-        assertThat(string).isInstanceOf(String.class);
-
-        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
-
-        CharSequence styledPart = null;
-
-        {
-            Spanned spanned = (Spanned) string;
-            StyleSpan[] spans = spanned.getSpans(0, spanned.length(), StyleSpan.class);
-            StyleSpan span = spans[0];
-            int start = spanned.getSpanStart(span);
-            int end = spanned.getSpanEnd(span);
-            styledPart = spanned.subSequence(start, end);
-        }
-
-        assertThat(styledPart).isNotNull();
-        assertThat(styledPart.toString()).isEqualTo("bold");
+        assertThat(quantityStringForZero).isEqualTo("others!");
+        assertThat(quantityStringForOne).isEqualTo("this is one");
+        assertThat(quantityStringForTwo).isEqualTo("others!"); // fallback
+        assertThat(quantityStringForThree).isEqualTo("others!"); //fallback
+        assertThat(quantityStringForALot).isEqualTo("others!");
     }
 
+    @Test
+    @Config(qualifiers = "sl")
+    public void testGetLocalizedQuantityString_androidUsesSLAndICUStringWithoutOthersPlural_returnNull() {
+        // https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sl
 
+        // In this test, the ICU only has only "ONE" plural. Since the "OTHERS" plural does not exist, we
+        // expect "null" to be returned
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 20);
+
+        assertThat(quantityStringForZero).isNull();
+        assertThat(quantityStringForOne).isEqualTo("this is one");
+        assertThat(quantityStringForTwo).isNull();
+        assertThat(quantityStringForThree).isNull();
+        assertThat(quantityStringForALot).isNull();
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testGetLocalizedQuantityString_ICUStringHasNoPlurals_returnNull() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_EMPTY, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_EMPTY, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_EMPTY, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_EMPTY, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_EMPTY, 20);
+
+        assertThat(quantityStringForZero).isNull();
+        assertThat(quantityStringForOne).isNull();
+        assertThat(quantityStringForTwo).isNull();
+        assertThat(quantityStringForThree).isNull();
+        assertThat(quantityStringForALot).isNull();
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testGetLocalizedQuantityString_ICUStringIsEmpty_returnNull() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, "", 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, "", 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, "", 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, "", 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, "", 20);
+
+        assertThat(quantityStringForZero).isNull();
+        assertThat(quantityStringForOne).isNull();
+        assertThat(quantityStringForTwo).isNull();
+        assertThat(quantityStringForThree).isNull();
+        assertThat(quantityStringForALot).isNull();
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testTranslateQuantityString_androidUsesSourceLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("car");
+        assertThat(stringTwo).isEqualTo("cars");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testTranslateQuantityString_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("αυτοκίνητο tx");
+        assertThat(stringTwo).isEqualTo("αυτοκίνητα tx");
+    }
+
+    @Test
+    @Config(qualifiers = "es-rES")
+    public void testTranslateQuantityStringWithDefaultMissingPolicy_ENSourceLocaleAndAndroidUsesUnsupportedLocale_returnSourceString() {
+        // The quantity string will be rendered using the source locale plural rules, which in this
+        // case is "en" and the default source strings
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("car");
+        assertThat(stringTwo).isEqualTo("cars");
+    }
+
+    @Test
+    @Config(qualifiers = "es-rES")
+    public void testTranslateQuantityStringWithDefaultMissingPolicy_SLSourceLocaleAndAndroidUsesUnsupportedLocale_returnSourceString() {
+        // The quantity string will be rendered using the source locale plural rules, which in this
+        // case is "sl" and the default source strings
+
+        LocaleState localeState = new LocaleState(mockContext,
+                "sl",
+                new String[]{"sl", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("car");
+        assertThat(stringTwo).isEqualTo("car 2");
+    }
+
+    @Test
+    public void testTranslateQuantityString_idDoesNotExist_exceptionIsThrown() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "sl",
+                new String[]{"sl", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        final NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        assertThrows(Resources.NotFoundException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                CharSequence stringOne = nativeCore.translateQuantityString(txResources, 0, 1);
+            }
+        });
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testTranslateQuantityString_testMode_returnPrefixedString() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        nativeCore.setTestMode(true);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = nativeCore.translateQuantityString(txResources, R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("test: αυτοκίνητο");
+        assertThat(stringTwo).isEqualTo("test: αυτοκίνητα");
+    }
+
+    // endregion quantity string
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
@@ -73,7 +73,7 @@ public class NativeCoreTest {
 
     private static final String ICU_STRING = "{cnt, plural, zero {zero} one {this is one} two {just two} few {just a few} many {a lot!} other {others!}}";
     private static final String ICU_STRING_SIMPLE = "{cnt, plural, one {this is one} other {others!}}";
-    private static final String ICU_STRING_NOOTHERs = "{cnt, plural, one {this is one}}";
+    private static final String ICU_STRING_OTHER_NOT_SPECIFIED = "{cnt, plural, one {this is one}}";
     private static final String ICU_STRING_EMPTY = "{cnt, plural, }";
 
     // region translate
@@ -439,8 +439,8 @@ public class NativeCoreTest {
     public void testGetLocalizedQuantityString_androidUsesSLAndICUStringWithoutOthersPlural_returnNull() {
         // https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sl
 
-        // In this test, the ICU only has only "ONE" plural. Since the "OTHERS" plural does not exist, we
-        // expect "null" to be returned
+        // In this test, the ICU only has the "ONE" plural. Since the "OTHERS" plural does not exist,
+        // we expect "null" to be returned for any given quantity.
 
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
@@ -450,14 +450,14 @@ public class NativeCoreTest {
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
         TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
 
-        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 0);
-        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 1);
-        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 2);
-        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 3);
-        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_NOOTHERs, 20);
+        String quantityStringForZero = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_OTHER_NOT_SPECIFIED, 0);
+        String quantityStringForOne = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_OTHER_NOT_SPECIFIED, 1);
+        String quantityStringForTwo = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_OTHER_NOT_SPECIFIED, 2);
+        String quantityStringForThree = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_OTHER_NOT_SPECIFIED, 3);
+        String quantityStringForALot = nativeCore.getLocalizedQuantityString(txResources, ICU_STRING_OTHER_NOT_SPECIFIED, 20);
 
         assertThat(quantityStringForZero).isNull();
-        assertThat(quantityStringForOne).isEqualTo("this is one");
+        assertThat(quantityStringForOne).isNull();
         assertThat(quantityStringForTwo).isNull();
         assertThat(quantityStringForThree).isNull();
         assertThat(quantityStringForALot).isNull();
@@ -465,7 +465,7 @@ public class NativeCoreTest {
 
     @Test
     @Config(qualifiers = "en")
-    public void testGetLocalizedQuantityString_ICUStringHasNoPlurals_returnNull() {
+    public void testGetLocalizedQuantityString_ICUStringWithOtherNotSpecified_returnNull() {
         LocaleState localeState = new LocaleState(mockContext,
                 "en",
                 new String[]{"en", "el"},

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/TxResourcesTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/TxResourcesTest.java
@@ -1,0 +1,267 @@
+package com.transifex.txnative;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Build;
+
+import com.transifex.common.LocaleData;
+import com.transifex.txnative.cache.TxMemoryCache;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.P)
+public class TxResourcesTest {
+
+    // The tests rely on the following directories:
+    //
+    // test/res/values
+    // test/res/values-el
+    // test/res/values-es
+
+    private Context mockContext;
+
+    @Before
+    public void setUp() {
+        // inject context provided by Robolectric
+        mockContext = ApplicationProvider.getApplicationContext();
+    }
+
+    private TxMemoryCache getElMemoryCache() {
+        HashMap<String, LocaleData.StringInfo> dic2 = new HashMap<>();
+        dic2.put("tx_test_key", new LocaleData.StringInfo("test ελ %d tx"));
+        dic2.put("tx_plural_test_key", new LocaleData.StringInfo("{cnt, plural, one {%d αυτοκίνητο} other {%d αυτοκίνητα}}"));
+        LocaleData.LocaleStrings elStrings = new LocaleData.LocaleStrings(dic2);
+
+        LocaleData.TranslationMap translationMap = new LocaleData.TranslationMap(2);
+        translationMap.put("el", elStrings);
+
+        TxMemoryCache memoryCache = new TxMemoryCache();
+        memoryCache.update(translationMap);
+
+        return memoryCache;
+    }
+
+    // region interface
+
+    @Test
+    public void testIsAndroidStringResource() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        assertThat(txResources.isAndroidStringResource(android.R.string.cancel)).isTrue();
+        assertThat(txResources.isAndroidStringResource(R.string.tx_test_key)).isFalse();
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetOriginalText() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getOriginalText(R.string.tx_test_key);
+
+        assertThat(string).isEqualTo("test ελ");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetOriginalQuantityText() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getOriginalQuantityText(R.plurals.tx_plural_test_key, 2);
+
+        assertThat(string).isEqualTo("αυτοκίνητα");
+    }
+
+
+    // endregion interface
+
+    // region overrides
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetText_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getText(R.string.tx_test_key);
+
+        assertThat(string).isEqualTo("test ελ %d tx");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetText_androidUsesSupportedLocaleAndIdDoesNotExist_exceptionIsThrown() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        assertThrows(Resources.NotFoundException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                CharSequence string =  txResources.getText(0);
+            }
+        });
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetTextDef_androidUsesSupportedLocaleAndIdDoesNotExist_defaultStringIsReturned() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getText(0, "default string");
+
+        assertThat(string).isEqualTo("default string");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetString_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getString(R.string.tx_test_key);
+
+        assertThat(string).isEqualTo("test ελ %d tx");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetStringFormat_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence string =  txResources.getString(R.string.tx_test_key, 9);
+
+        assertThat(string).isEqualTo("test ελ 9 tx");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetQuantityText_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = txResources.getQuantityText(R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = txResources.getQuantityText(R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("%d αυτοκίνητο");
+        assertThat(stringTwo).isEqualTo("%d αυτοκίνητα");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetQuantityText_androidUsesSupportedLocaleAndIdDoesNotExist_exceptionIsThrown() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        final TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        assertThrows(Resources.NotFoundException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                CharSequence stringOne = txResources.getQuantityText(0, 1);
+            }
+        });
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetQuantityString_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = txResources.getQuantityString(R.plurals.tx_plural_test_key, 1);
+        CharSequence stringTwo = txResources.getQuantityString(R.plurals.tx_plural_test_key, 2);
+
+        assertThat(stringOne).isEqualTo("%d αυτοκίνητο");
+        assertThat(stringTwo).isEqualTo("%d αυτοκίνητα");
+    }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetQuantityStringFormat_androidUsesSupportedLocale() {
+        LocaleState localeState = new LocaleState(mockContext,
+                "en",
+                new String[]{"en", "el"},
+                null);
+        TxMemoryCache elMemoryCache = getElMemoryCache();
+        NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, elMemoryCache, null);
+        TxResources txResources = new TxResources(mockContext.getResources(), nativeCore);
+
+        CharSequence stringOne = txResources.getQuantityString(R.plurals.tx_plural_test_key, 1, 1);
+        CharSequence stringTwo = txResources.getQuantityString(R.plurals.tx_plural_test_key, 2, 2);
+
+        assertThat(stringOne).isEqualTo("1 αυτοκίνητο");
+        assertThat(stringTwo).isEqualTo("2 αυτοκίνητα");
+    }
+
+    // endregion overrides
+}

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxUpdateFilterCacheTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/cache/TxUpdateFilterCacheTest.java
@@ -65,7 +65,7 @@ public class TxUpdateFilterCacheTest {
 
     @Test
     public void testUpdate_replaceAllPolicy_getCorrectMap() {
-        int policy = TxUpdateFilterCache.REPLACE_ALL;
+        int policy = TxUpdateFilterCache.TxCacheUpdatePolicy.REPLACE_ALL;
         TxMemoryCache internalCache = new TxMemoryCache();
         internalCache.update(getTranslations1());
         TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
@@ -76,7 +76,7 @@ public class TxUpdateFilterCacheTest {
 
     @Test
     public void testUpdate_updateUsingTranslatedPolicy_getCorrectMap() {
-        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        int policy = TxUpdateFilterCache.TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED;
         TxMemoryCache internalCache = new TxMemoryCache();
         internalCache.update(getTranslations1());
         TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
@@ -90,7 +90,7 @@ public class TxUpdateFilterCacheTest {
         // This tests makes sure that TxUpdateFilterCache updates the internal cache by calling
         // its update() method and not by accidentally changing the internal cache's map
 
-        int policy = TxUpdateFilterCache.REPLACE_ALL;
+        int policy = TxUpdateFilterCache.TxCacheUpdatePolicy.REPLACE_ALL;
         TxMemoryCache internalCache = new TxMemoryCache();
         internalCache.update(getTranslations1());
         TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, new TxReadonlyCacheDecorator(internalCache));
@@ -104,7 +104,7 @@ public class TxUpdateFilterCacheTest {
         // This tests makes sure that TxUpdateFilterCache updates the internal cache by calling
         // its update() method and not by accidentally changing the internal cache's map
 
-        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        int policy = TxUpdateFilterCache.TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED;
         TxMemoryCache internalCache = new TxMemoryCache();
         internalCache.update(getTranslations1());
         TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, new TxReadonlyCacheDecorator(internalCache));
@@ -117,7 +117,7 @@ public class TxUpdateFilterCacheTest {
     public void testUpdate_updateUsingTranslatedPolicyAndEmptyInternalCache_addNewLocale() {
         // We make sure that a new locale can be added when UPDATE_USING_TRANSLATED is used.
 
-        int policy = TxUpdateFilterCache.UPDATE_USING_TRANSLATED;
+        int policy = TxUpdateFilterCache.TxCacheUpdatePolicy.UPDATE_USING_TRANSLATED;
         TxMemoryCache internalCache = new TxMemoryCache();
         TxUpdateFilterCache updateFilterCache = new TxUpdateFilterCache(policy, internalCache);
         updateFilterCache.update(getTranslations1());

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicyTest.java
@@ -47,4 +47,19 @@ public class AndroidMissingPolicyTest {
 
         assertThat(translated).isEqualTo("test ελ");
     }
+
+    @Test
+    @Config(qualifiers = "el-rGR")
+    public void testGetQuantityString() {
+        // We test if AndroidMissingPolicy can return the el translation found in the app's
+        // test/res/values-el/strings.xml
+
+        CharSequence sourceString = "dummy source string";
+        String resourceEntryName = mockContext.getResources().getResourceEntryName(R.plurals.tx_plural_test_key);
+
+        AndroidMissingPolicy policy = new AndroidMissingPolicy(mockContext);
+        CharSequence translated = policy.getQuantityString(sourceString, R.plurals.tx_plural_test_key, 1, resourceEntryName, "el");
+
+        assertThat(translated).isEqualTo("αυτοκίνητο");
+    }
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicyTest.java
@@ -69,4 +69,50 @@ public class CompositeMissingPolicyTest {
 
         assertThat(result).isEqualTo("test");
     }
+
+    @Test
+    public void testGetQuantityString_normal() {
+        // Mock a missing policy that returns sourceString + " end"
+        // and a missing policy that returns "start " + sourceString + " end2"
+        MissingPolicy missingPolicy1 = mock(MissingPolicy.class);
+        when(missingPolicy1.getQuantityString(anyString(), anyInt(), anyInt(), anyString(), anyString()))
+                .thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return args[0] + " end";
+                    }
+                });
+        MissingPolicy missingPolicy2 = mock(MissingPolicy.class);
+        when(missingPolicy2.getQuantityString(anyString(), anyInt(), anyInt(), anyString(), anyString()))
+                .thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return "start " + args[0] + " end2";
+                    }
+                });
+
+        MissingPolicy[] missingPolicies = new MissingPolicy[]{missingPolicy1, missingPolicy2};
+        CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(missingPolicies);
+        String result = compositeMissingPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale).toString();
+
+        // Verify that the get() methods of the missing policies were called in order and had the
+        // expected arguments
+        InOrder inOrder = inOrder(missingPolicy1, missingPolicy2);
+        inOrder.verify(missingPolicy1).getQuantityString("test", stringId, 1, stringResourceName, locale);
+        inOrder.verify(missingPolicy2).getQuantityString("test end", stringId, 1, stringResourceName, locale);
+        inOrder.verifyNoMoreInteractions();
+        // Assert final result
+        assertThat(result).isEqualTo("start test end end2");
+    }
+
+
+    @Test
+    public void testGetQuantityString_emptyPolicyArray_returnSourceString() {
+        CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(new MissingPolicy[]{});
+        String result = compositeMissingPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale).toString();
+
+        assertThat(result).isEqualTo("test");
+    }
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicyTest.java
@@ -2,8 +2,6 @@ package com.transifex.txnative.missingpolicy;
 
 import org.junit.Test;
 
-import java.util.Date;
-
 import static com.google.common.truth.Truth.assertThat;
 
 public class PseudoTranslationPolicyTest {
@@ -11,6 +9,52 @@ public class PseudoTranslationPolicyTest {
     final int stringId = 0;
     final String stringResourceName = "dummy_name";
     final String locale = "el";
+
+    @Test
+    public void testProcessString() {
+        String sourceString = "The quick\n brown fox \nένα!";
+        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
+        CharSequence translated = policy.processString(sourceString);
+
+        assertThat(translated).isEqualTo("Ťȟê ʠüıċǩ\n ƀȓøẁñ ƒøẋ \nένα!");
+    }
+
+    @Test
+    public void testProcessString_formatSpecifiers_notAffected() {
+        // Make sure that format specifiers are not affected
+        String sourceString = "This is a %s %B test";
+        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
+        CharSequence translated = policy.processString(sourceString);
+
+        assertThat(translated).isEqualTo("Ťȟıš ıš à %s %B ťêšť");
+    }
+
+    @Test
+    public void testProcessString_formatSpecifiers2_notAffected() {
+        String sourceString = "This is a %32.12f test";
+        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
+        CharSequence translated = policy.processString(sourceString);
+
+        assertThat(translated).isEqualTo("Ťȟıš ıš à %32.12f ťêšť");
+    }
+
+    @Test
+    public void testProcessString_formatSpecifiers3_notAffected() {
+        String sourceString = "This is a |%010d| test";
+        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
+        CharSequence translated = policy.processString(sourceString);
+
+        assertThat(translated).isEqualTo("Ťȟıš ıš à |%010d| ťêšť");
+    }
+
+    @Test
+    public void testProcessString_formatSpecifierWithDate_notAffected() {
+        String sourceString = "This is a %tM test";
+        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
+        CharSequence translated = policy.processString(sourceString);
+
+        assertThat(translated).isEqualTo("Ťȟıš ıš à %tM ťêšť");
+    }
 
     @Test
     public void testGet() {
@@ -22,38 +66,11 @@ public class PseudoTranslationPolicyTest {
     }
 
     @Test
-    public void testGet_stringFormat() {
-        String sourceString = "This is a %s %B test";
+    public void testGetQuantityString() {
+        String sourceString = "The quick\n brown fox \nένα!";
         PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.getQuantityString(sourceString, stringId, 1, stringResourceName, locale);
 
-        assertThat(translated).isEqualTo("Ťȟıš ıš à %s %B ťêšť");
-    }
-
-    @Test
-    public void testGet_stringFormat2() {
-        String sourceString = "This is a %32.12f test";
-        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
-
-        assertThat(translated).isEqualTo("Ťȟıš ıš à %32.12f ťêšť");
-    }
-
-    @Test
-    public void testGet_stringFormat3() {
-        String sourceString = "This is a |%010d| test";
-        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
-
-        assertThat(translated).isEqualTo("Ťȟıš ıš à |%010d| ťêšť");
-    }
-
-    @Test
-    public void testGet_stringFormatWithDate() {
-        String sourceString = "This is a %tM test";
-        PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
-
-        assertThat(translated).isEqualTo("Ťȟıš ıš à %tM ťêšť");
+        assertThat(translated).isEqualTo("Ťȟê ʠüıċǩ\n ƀȓøẁñ ƒøẋ \nένα!");
     }
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/SourceStringPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/SourceStringPolicyTest.java
@@ -18,4 +18,11 @@ public class SourceStringPolicyTest {
                 .isEqualTo("test");
     }
 
+    @Test
+    public void testGetQuantityString() {
+        SourceStringPolicy sourceStringPolicy = new SourceStringPolicy();
+
+        assertThat(sourceStringPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale))
+                .isEqualTo("test");
+    }
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
@@ -23,57 +23,57 @@ public class WrappedStringPolicyTest {
     final String locale = "el";
 
     @Test
-    public void testGet_normal() {
+    public void testWrapString_normal() {
         WrappedStringPolicy policy = new WrappedStringPolicy("<", " !end");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isEqualTo("<The quick\n brown fox !end");
     }
 
     @Test
-    public void testGet_startIsNull_justEndIsAppended() {
+    public void testWrapString_startIsNull_justEndIsAppended() {
         WrappedStringPolicy policy = new WrappedStringPolicy(null, " !end");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isEqualTo("The quick\n brown fox !end");
     }
 
     @Test
-    public void testGet_startIsEmpty_justEndIsAppended() {
+    public void testWrapString_startIsEmpty_justEndIsAppended() {
         WrappedStringPolicy policy = new WrappedStringPolicy("", " !end");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isEqualTo("The quick\n brown fox !end");
     }
 
     @Test
-    public void testGet_endIsNull_justStartIsPrefixed() {
+    public void testWrapString_endIsNull_justStartIsPrefixed() {
         WrappedStringPolicy policy = new WrappedStringPolicy("<", null);
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isEqualTo("<The quick\n brown fox");
     }
 
     @Test
-    public void testGet_endIsEmpty_justStartIsPrefixed() {
+    public void testWrapString_endIsEmpty_justStartIsPrefixed() {
         WrappedStringPolicy policy = new WrappedStringPolicy("<", "");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isEqualTo("<The quick\n brown fox");
     }
 
     @Test
-    public void testGet_spannedString() {
+    public void testWrapString_spannedString() {
         // Test that a spanned source string keeps its spans after being processed
 
         WrappedStringPolicy policy = new WrappedStringPolicy("start! ", " !end");
         CharSequence sourceString = HtmlCompat.fromHtml("The quick <b>brown</b> fox", HtmlCompat.FROM_HTML_MODE_LEGACY);
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isInstanceOf(Spanned.class);
         Spanned spanned = (Spanned) translated;
@@ -87,5 +87,23 @@ public class WrappedStringPolicyTest {
         assertThat(styledPart.toString()).isEqualTo("brown");
 
         assertThat(translated.toString()).isEqualTo("start! The quick brown fox !end");
+    }
+
+    @Test
+    public void testGet_normal() {
+        WrappedStringPolicy policy = new WrappedStringPolicy("<", " !end");
+        String sourceString = "The quick\n brown fox";
+        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+
+        assertThat(translated).isEqualTo("<The quick\n brown fox !end");
+    }
+
+    @Test
+    public void testGetQuantityString_normal() {
+        WrappedStringPolicy policy = new WrappedStringPolicy("<", " !end");
+        String sourceString = "The quick\n brown fox";
+        CharSequence translated = policy.getQuantityString(sourceString, stringId, 1, stringResourceName, locale);
+
+        assertThat(translated).isEqualTo("<The quick\n brown fox !end");
     }
 }

--- a/TransifexNativeSDK/txsdk/src/test/res/values-el/strings.xml
+++ b/TransifexNativeSDK/txsdk/src/test/res/values-el/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="tx_test_key">test ελ</string>
+    <plurals name="tx_plural_test_key">
+        <item quantity="other">αυτοκίνητα</item>
+        <item quantity="one">αυτοκίνητο</item>
+    </plurals>
 </resources>

--- a/TransifexNativeSDK/txsdk/src/test/res/values/strings.xml
+++ b/TransifexNativeSDK/txsdk/src/test/res/values/strings.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="tx_test_key">test</string>
+    <plurals name="tx_plural_test_key">
+        <item quantity="other">cars</item>
+        <item quantity="one">car</item>
+        <!-- "two" is not needed for EN, but it's useful for testing -->
+        <item quantity="two">car 2</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Plurals class was created. Methods to convert from/to ICU
string were added.

StringXMLConverter can now parse "plurals" from Android
string resources. They are converted to Plurals objects which
are serialized to ICU strings.

Added translateQuantityString() to NativeCore. The span functionality
was removed from transate() method into getSpannedString() so that
it's reusable.

txsdk has now a strings.xml that contains a plurals resource, named
"tx_plurals". Via "tx_plurals" we take advantage of Android's localization
system to get the correct plural for a given quantity under the current
locale's rules.

MissingPolicy interface has a new method: getQuantityString().
All implementation were updated and new unit tests were added.

TxResources. The signatures of some methods have been updated
to reflect that they throw NotFoundException. getQuantityString()
implementation can now call NativeCore#translateQuantityString().

The error that CDS responds with when pushing strings is
now parsed into TxPostResponseData.Error object.
CDSHandler#pushSourceStrings() used to return "null" when a
call failed. Now, it may return aTxPostResponseData object
so that the error is retuned to the caller. All callers have been
refactored. Unit tests were added.

The update policy strings in TxStandardCache are not part
of TxCacheUpdatePolicy interface. Refactoring was performed
where necessary.

Updated app's layout so that all views are inside a scrollview.