### PR TITLE
Publish in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Transifex Native Android SDK
 
 [![CI](https://github.com/transifex/transifex-java/actions/workflows/gradle.yml/badge.svg)](https://github.com/transifex/transifex-java/actions/workflows/gradle.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk)
 
 Transifex Native Android SDK is a collection of tools to easily localize your Android applications 
 using [Transifex Native](https://www.transifex.com/native/). The Android library can fetch translations 
 over the air (OTA) to your apps and the command line tool can upload your app's source strings to Transifex.
 
-The library's minimum supported SDK is `18` (Android 4.3) and uses [appcompat](https://developer.android.com/jetpack/androidx/releases/appcompat) `1.2.0`.
-
 Learn more about [Transifex Native](https://docs.transifex.com/transifex-native-sdk-overview/introduction).
 
-//TODO:
-You can find the SDK's documentation here.
+The full documentation is available at https://transifex.github.io/transifex-java/
 
 ## Usage
 
@@ -21,7 +19,16 @@ advantage of the features that Transifex Native offers, such as OTA translations
 
 ### SDK installation
 
-//TODO: write about gradle dependency
+Include the dependency:
+
+```groovy
+implementation 'com.transifex.txnative:txsdk:0.x.y'
+```
+
+Please replace `x` and `y` with the latest version numbers: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk)
+
+
+The library's minimum supported SDK is 18 (Android 4.3) and uses [appcompat](https://developer.android.com/jetpack/androidx/releases/appcompat) 1.2.0.
 
 ### SDK configuration 
 
@@ -185,7 +192,7 @@ return new TxFileOutputCacheDecorator(
 
 If you want to have your memory cache updated with the new translations when `fetchTranslations()` is called, you can remove the `TXReadonlyCacheDecorator`.
 
-## Sample app
+### Sample app
 
 You can see the SDK used and configured in more advanced ways in the provided sample app.
 
@@ -225,28 +232,36 @@ To use the tool on your app's Android Studio project, enter the root directory o
 #### Help
 
 `transifex`, `transifex -h`, `transifex --help`
+
 Displays a help dialog with all the options and commands.
 
 `transifex help <command>`
+
 Get help for a particular command.
 
 #### Pushing
 
 `transifex push -t <transifex_token> -s <transifex_secret> -m <app_module_name>`
+
 Pushes the source strings of your app found in a module named "app_module_name". The tool reads the `strings.xml` resource file found in the main source set of the specified module: `app_module_name/src/main/res/values/strings.xml`. It processes it and pushes the result to the Transifex CDS. 
 
 `transifex push -t <transifex_token> -s <transifex_secret> -f path/to/strings1.xml path2/to/strings2.xml`
+
 If your app has a more complex string setup, you can specify one or more string resource files.
 
 `transifex clear -t <transifex_token> -s <transifex_secret>`
+
 Clears all existing resource content from CDS. This action will also remove existing localizations.
 
 #### Pulling
 
 `transifex pull -t <transifex_token> -m <app_module_name> -l <locale>...`
+
 Downloads the translations from Transifex CDS for the specified locales and stores them in txstrings.json files under the "assets" directory of the main source set of the specified app module: `app_module_name/src/main/assets/txnative`. The directory is created if needed. These files will be bundled inside your app and accessed by TxNative.
 
+
 `transifex pull -t <transifex_token> -d <directory> -l <locale>...`
+
 If you have a different setup, you can enter the path to your app's `assets` directory.
 
 ## Advanced topics

--- a/TransifexNativeSDK/app/build.gradle
+++ b/TransifexNativeSDK/app/build.gradle
@@ -30,11 +30,11 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/TransifexNativeSDK/build.gradle
+++ b/TransifexNativeSDK/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -16,10 +16,47 @@ buildscript {
     }
 }
 
+ext {
+    sdkVersionCode = 1                      // version code for txsdk
+    sdkVersion = '0.1.0'                    // version for txsdk and common
+    pomGroupID = "com.transifex.txnative"   // pom group id for txsdk and common
+
+    cliVersion = '0.1.0'                    // clitool version
+}
+
 allprojects {
     repositories {
         google()
         jcenter()
+    }
+}
+
+gradle.projectsEvaluated {
+
+    task aggregatedJavadoc(type: Javadoc, description: 'Generate javadocs from "common" and "txsdk" modules',
+            group: JavaBasePlugin.DOCUMENTATION_GROUP) {
+        options.encoding 'utf-8'
+        options {
+            addStringOption 'docencoding', 'utf-8'
+            addStringOption 'charset', 'utf-8'
+            addStringOption 'overview', 'doc/readme.html'
+            links 'https://docs.oracle.com/javase/7/docs/api/'
+            links 'https://d.android.com/reference'
+            links 'https://developer.android.com/reference/androidx/'
+        }
+        title = "Transifex Native SDK $sdkVersion"
+
+        destinationDir project.file("$project.buildDir/docs/javadoc")
+
+        Set<Project> projectSet = subprojects.findAll{ subproject ->
+            subproject.name == 'txsdk' || subproject.name == 'common'
+        }
+
+        // Merge properties of androidJavadoc tasks (which is supported by both subprojects)
+        source = projectSet.androidJavadoc.source
+        classpath = project.files(projectSet.androidJavadoc.classpath)
+        excludes = projectSet.androidJavadoc.excludes.flatten().unique()
+        includes = projectSet.androidJavadoc.includes.flatten().unique()
     }
 }
 

--- a/TransifexNativeSDK/clitool/build.gradle
+++ b/TransifexNativeSDK/clitool/build.gradle
@@ -5,7 +5,9 @@ plugins {
 jar {
     manifest {
         attributes(
-                'Main-Class': 'com.transifex.clitool.MainClass'
+                'Main-Class': 'com.transifex.clitool.MainClass',
+                "Implementation-Title": "Transifex command-line tool for Android",
+                "Implementation-Version": rootProject.ext.cliVersion
         )
     }
 
@@ -35,12 +37,12 @@ tasks.withType(Test) {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'org.jdom:jdom:2.0.2'
     implementation 'info.picocli:picocli:4.6.1'
     implementation project(':common')
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'com.google.code.gson:gson:2.8.6'

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -33,12 +33,21 @@ import static picocli.CommandLine.ParentCommand;
  * The execution and argument parsing is handled by picocli. Each subcommand is implemented in its
  * own class.
  */
-@Command(name = "transifex", version = "transifex 0.1", mixinStandardHelpOptions = true,
+@Command(name = "transifex", versionProvider  = MainClass.VersionProvider.class, mixinStandardHelpOptions = true,
         subcommands = {MainClass.PushCommand.class, MainClass.ClearCommand.class,
                 MainClass.PullCommand.class, CommandLine.HelpCommand.class},
         description = "Transifex command-line tool for Android",
         synopsisSubcommandLabel = "(push | pull | clear)", sortOptions = false)
 public class MainClass {
+
+    public static class VersionProvider implements CommandLine.IVersionProvider {
+
+        @Override
+        public String[] getVersion() throws Exception {
+            // Get the version that was specified in the jar gradle task
+            return new String[]{VersionProvider.class.getPackage().getImplementationVersion()};
+        }
+    }
 
     private static final String TAG = MainClass.class.getSimpleName();
     private static final Logger LOGGER = Logger.getLogger(TAG);

--- a/TransifexNativeSDK/common/build.gradle
+++ b/TransifexNativeSDK/common/build.gradle
@@ -16,12 +16,14 @@ tasks.withType(Test) {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'net.moznion:uribuilder-tiny:2.7.1'
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'commons-io:commons-io:2.6'
 }
+
+apply from: '../publish-helper.gradle'

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -3,7 +3,6 @@ package com.transifex.common;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationMapStorage.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationMapStorage.java
@@ -23,7 +23,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * A class that allows storing and loading a {@link LocaleData.TranslationMap} to / from disk.
+ * A class that allows storing and loading a {@link LocaleData.TranslationMap} to/from disk.
  * <p>
  * The {@link LocaleData.TranslationMap} is represented in disk in the following format:
  * <pre>{@code

--- a/TransifexNativeSDK/doc/readme.html
+++ b/TransifexNativeSDK/doc/readme.html
@@ -1,0 +1,215 @@
+<html><head><style>body {
+   color: black;
+}
+</style></head><body><h1 id="transifex-native-android-sdk">Transifex Native Android SDK</h1>
+<p><a href="https://github.com/transifex/transifex-java/actions/workflows/gradle.yml"><img src="https://github.com/transifex/transifex-java/actions/workflows/gradle.yml/badge.svg" alt="CI"></a>
+<a href="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk"><img src="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg" alt="Maven Central"></a></p>
+<p>Transifex Native Android SDK is a collection of tools to easily localize your Android applications 
+using <a href="https://www.transifex.com/native/">Transifex Native</a>. The Android library can fetch translations 
+over the air (OTA) to your apps and the command line tool can upload your app&#39;s source strings to Transifex.</p>
+<p>Learn more about <a href="https://docs.transifex.com/transifex-native-sdk-overview/introduction">Transifex Native</a>.</p>
+<p>The full documentation is available at <a href="https://transifex.github.io/transifex-java/">https://transifex.github.io/transifex-java/</a></p>
+<h2 id="usage">Usage</h2>
+<p>The SDK allows you to keep using the same string methods that Android 
+provides, such as <code>getString(int id)</code>, <code>getText(int id)</code>, etc, but at the same time taking 
+advantage of the features that Transifex Native offers, such as OTA translations.</p>
+<h3 id="sdk-installation">SDK installation</h3>
+<p>Include the dependency:</p>
+<pre><code class="lang-groovy"><span class="hljs-keyword">implementation</span> <span class="hljs-string">'com.transifex.txnative:txsdk:0.x.y'</span>
+</code></pre>
+<p>Please replace <code>x</code> and <code>y</code> with the latest version numbers: <a href="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk"><img src="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg" alt="Maven Central"></a></p>
+<p>The library&#39;s minimum supported SDK is 18 (Android 4.3) and uses <a href="https://developer.android.com/jetpack/androidx/releases/appcompat">appcompat</a> 1.2.0.</p>
+<h3 id="sdk-configuration">SDK configuration</h3>
+<p>Configure the SDK in your <code>Application</code> class. </p>
+<p>The language codes supported by Transifex can be found <a href="https://www.transifex.com/explore/languages/">here</a>. They can either use 2 characters, such as <code>es</code>, or specify the regional code as well, such as <code>es_ES</code>. Keep in mind that in the sample code below you will have to replace <code>&lt;transifex_token&gt;</code> with the actual token that is associated with your Transifex project and resource.</p>
+<pre><code class="lang-java">    <span class="hljs-meta">@Override</span>
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">onCreate</span><span class="hljs-params">()</span> </span>{
+        <span class="hljs-keyword">super</span>.onCreate();
+
+        <span class="hljs-comment">// Initialize TxNative</span>
+        String token = <span class="hljs-string">"&lt;transifex_token&gt;"</span>;
+
+        LocaleState localeState = <span class="hljs-keyword">new</span> LocaleState(getApplicationContext(),
+                <span class="hljs-string">"en"</span>,                                                                 <span class="hljs-comment">// source locale</span>
+                <span class="hljs-keyword">new</span> String[]{<span class="hljs-string">"en"</span>, <span class="hljs-string">"el"</span>, <span class="hljs-string">"de"</span>, <span class="hljs-string">"fr"</span>, <span class="hljs-string">"ar"</span>, <span class="hljs-string">"sl"</span>, <span class="hljs-string">"es_ES"</span>, <span class="hljs-string">"es_MX"</span>},   <span class="hljs-comment">// supported locales</span>
+                <span class="hljs-keyword">null</span>);
+
+        TxNative.init(
+                getApplicationContext(),   <span class="hljs-comment">// application context</span>
+                localeState,               <span class="hljs-comment">// a LocaleState instance</span>
+                token,                     <span class="hljs-comment">// token</span>
+                <span class="hljs-keyword">null</span>,                      <span class="hljs-comment">// cdsHost URL</span>
+                <span class="hljs-keyword">null</span>,                      <span class="hljs-comment">// a TxCache implementation</span>
+                <span class="hljs-keyword">null</span>);                     <span class="hljs-comment">// a MissingPolicy implementation</span>
+
+        <span class="hljs-comment">// Fetch all translations from CDS</span>
+        TxNative.fetchTranslations(<span class="hljs-keyword">null</span>);
+     }
+</code></pre>
+<p>In this example, the SDK uses its default cache, <code>TxStandardCache</code>, and missing policy, <code>SourceStringPolicy</code>. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.</p>
+<p>If you want to enable <a href="https://developer.android.com/guide/topics/resources/multilingual-support.html">multilingual support</a> starting from Android N, place the supported app languages in your app&#39;s gradle file:</p>
+<pre><code class="lang-gradle"><span class="hljs-class">android </span>{
+    ...
+    <span class="hljs-class">defaultConfig </span>{
+
+        resConfigs <span class="hljs-string">"en"</span>, <span class="hljs-string">"el"</span>, <span class="hljs-string">"de"</span>, <span class="hljs-string">"fr"</span>, <span class="hljs-string">"ar"</span>, <span class="hljs-string">"sl"</span>, <span class="hljs-string">"es_ES"</span>, <span class="hljs-string">"es_MX"</span>
+
+    }
+</code></pre>
+<h3 id="context-wrapping">Context Wrapping</h3>
+<p>The SDK&#39;s functionality is enabled by wrapping the context, so that all string resource related methods, such a <a href="https://developer.android.com/reference/android/content/res/Resources#getString(int,%20java.lang.Object..."><code>getString()</code></a>), <a href="https://developer.android.com/reference/android/content/res/Resources#getText(int"><code>getText()</code></a>), flow through the SDK.</p>
+<p>To enable context wrapping in your activity, use the following code or have your activity extend a base class:</p>
+<pre><code class="lang-java">public <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">BaseActivity</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Activity</span> </span>{
+
+    <span class="hljs-meta">@Override</span>
+    <span class="hljs-keyword">protected</span> void attachBaseContext(<span class="hljs-type">Context</span> base) {
+        <span class="hljs-keyword">super</span>.attachBaseContext(<span class="hljs-type">TxNative</span>.wrap(base));
+    }
+
+}
+</code></pre>
+<p>If your activity extends <code>AppCompatActivity</code> activity, use the following code or have your activity extend a base class:</p>
+<pre><code class="lang-java">public <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">BaseAppCompatActivity</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">AppCompatActivity</span> </span>{
+
+    <span class="hljs-keyword">private</span> <span class="hljs-type">TxContextWrappingDelegate</span> mAppCompatDelegate;
+    <span class="hljs-keyword">private</span> <span class="hljs-type">Resources</span> mResources;
+
+    <span class="hljs-meta">@NonNull</span>
+    <span class="hljs-meta">@Override</span>
+    public <span class="hljs-type">AppCompatDelegate</span> getDelegate() {
+        <span class="hljs-keyword">if</span> (mAppCompatDelegate == <span class="hljs-literal">null</span>) {
+            mAppCompatDelegate = <span class="hljs-keyword">new</span> <span class="hljs-type">TxContextWrappingDelegate</span>(<span class="hljs-keyword">super</span>.getDelegate());
+        }
+        <span class="hljs-keyword">return</span> mAppCompatDelegate;
+    }
+
+    <span class="hljs-meta">@SuppressLint</span>(<span class="hljs-string">"RestrictedApi"</span>)
+    <span class="hljs-meta">@Override</span>
+    public <span class="hljs-type">Resources</span> getResources() {
+        <span class="hljs-keyword">if</span> (mResources == <span class="hljs-literal">null</span> &amp;&amp; <span class="hljs-type">VectorEnabledTintResources</span>.shouldBeUsed()) {
+            mResources = <span class="hljs-keyword">new</span> <span class="hljs-type">VectorEnabledTintResourcesWrapper</span>(<span class="hljs-keyword">this</span>, getBaseContext().getResources());
+        }
+        <span class="hljs-keyword">return</span> mResources == <span class="hljs-literal">null</span> ? <span class="hljs-keyword">super</span>.getResources() : mResources;
+    }
+}
+</code></pre>
+<p>If you want to use the SDK outside an activity&#39;s context, such as a service context, make sure that you wrap the context:</p>
+<pre><code class="lang-java">public <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">SimpleIntentService</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">JobIntentService</span> </span>{
+
+    <span class="hljs-meta">@Override</span>
+    <span class="hljs-keyword">protected</span> void attachBaseContext(<span class="hljs-type">Context</span> newBase) {
+        <span class="hljs-keyword">super</span>.attachBaseContext(<span class="hljs-type">TxNative</span>.generalWrap(newBase));
+    }
+}
+</code></pre>
+<p>If you want to use the SDK in some arbitrary place where you can get your application&#39;s context, please do the following:</p>
+<pre><code class="lang-java">    ...
+    <span class="hljs-comment">// Wrap the context</span>
+    Context wrappedContext = TxNative.generalWrap(getApplicationContext()); 
+    <span class="hljs-comment">// Use the wrapped context for getting a string</span>
+    wrappedContext.getString();
+</code></pre>
+<p>If you want to disable the SDK functionality, don&#39;t initialize it and don&#39;t call any <code>TxNative</code> methods. <code>TxNative.wrap()</code> and <code>TxNative.generalWrap()</code> will be a no-op and the context will not be wrapped. Thus, all <code>getString()</code> etc methods, won&#39;t flow through the SDK.</p>
+<h3 id="fetching-translations">Fetching translations</h3>
+<p>As soon as <code>fetchTranslations()</code> is called, the SDK will attempt to download the 
+translations for all locales - except for the source locale - that are defined in the 
+initialization of <code>TxNative</code>. </p>
+<p>The <code>fetchTranslations()</code> method in the previous example is called as soon as the application launches, but that&#39;s not required. Depending on the application, the developer might choose to call that method whenever it is most appropriate (for example, each time the application is brought to the foreground or when the internet connectivity is established).</p>
+<h3 id="invalidating-cds-cache">Invalidating CDS cache</h3>
+<p>The cache of CDS has a TTL of 30 minutes. If you update some translations on Transifex 
+and you need to see them on your app immediately, you need to make an HTTP request 
+to the <a href="https://github.com/transifex/transifex-delivery/#invalidate-cache">invalidation endpoint</a> of CDS.</p>
+<h3 id="standard-cache">Standard Cache</h3>
+<p>The default cache strategy used by the SDK, if no other cache is provided by the developer, is the <code>TxStandardCache.getCache()</code>. The standard cache operates by making use of the publicly exposed classes and interfaces from the <code>com.transifex.txnative.cache</code> package of the SDK, so it&#39;s easy to construct another cache strategy if that&#39;s desired.</p>
+<p>The standard cache is initialized with a memory cache that manages all cached entries in memory. When the memory cache gets initialized, it tries to look up if there are any already stored translations in the file system:</p>
+<ul>
+<li>First, it looks for translations saved in the app&#39;s <a href="https://developer.android.com/reference/android/content/res/AssetManager">Assets directory</a> that may have been offered by the developer, using the command-line tool when building the app.</li>
+<li>Secondly, it looks for translations in the app&#39;s <a href="https://developer.android.com/training/data-storage/app-specific#internal-create-cache">internal cache directory</a>, in case the app had already downloaded the translations from the server from a previous launch. These translations take precedence over the previous ones, if found.</li>
+</ul>
+<p>Whenever new translations are fetched from the server using the <code>fetchTranslations()</code> method, the standard cache is updated and those translations are stored as-is in the app&#39;s cache directory, in the same directory used previsouly during initialization. The in-memory cache though is not affected by the update. An app restart is required to read the newly saved translations.</p>
+<h4 id="alternative-cache-strategy">Alternative cache strategy</h4>
+<p>The SDK allows you to implement your own cache from scratch by implementing the <code>TxCache</code> interface. Alternatively, you may change the standard cache strategy by implementing your own using the SDK&#39;s publicly exposed classes.</p>
+<p>In order to achieve that, you can create a a method that returns a <code>TxCache</code> instance, just like in the <code>TxStandardCache.getCache()</code> case. For example, the standard cache is created as follows:</p>
+<pre><code><span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-type">TxFileOutputCacheDecorator</span>(
+                &lt;cached Translations Directory&gt;,
+                <span class="hljs-keyword">new</span> <span class="hljs-type">TXReadonlyCacheDecorator</span>(
+                        <span class="hljs-keyword">new</span> <span class="hljs-type">TxProviderBasedCache</span>(
+                                &lt;providers array&gt;,
+                                <span class="hljs-keyword">new</span> <span class="hljs-type">TxUpdateFilterCache</span>(
+                                        &lt;update policy&gt;,
+                                        <span class="hljs-keyword">new</span> <span class="hljs-type">TxMemoryCache</span>()
+                                )
+                        )
+                )
+        );
+</code></pre><p>If you want to have your memory cache updated with the new translations when <code>fetchTranslations()</code> is called, you can remove the <code>TXReadonlyCacheDecorator</code>.</p>
+<h3 id="sample-app">Sample app</h3>
+<p>You can see the SDK used and configured in more advanced ways in the provided sample app.</p>
+<h2 id="transifex-command-line-tool">Transifex Command Line Tool</h2>
+<p>Transifex Command Line Tool is a command line tool that can assist developers in pushing the source strings of an Android app to Transifex.</p>
+<h3 id="building">Building</h3>
+<p>To build the tool, enter the <code>TransifexNativeSDK</code> directory and run from the command line:</p>
+<pre><code><span class="hljs-selector-tag">gradlew</span> <span class="hljs-selector-pseudo">:clitool</span><span class="hljs-selector-pseudo">:assemble</span>
+</code></pre><p>You can find the generated &quot;.jar&quot; file at <code>clitool/build/libs/transifex.jar</code>. You can copy it wherever you want.</p>
+<h3 id="running">Running</h3>
+<p>To run the tool, type:</p>
+<pre><code>java -jar /path/<span class="hljs-keyword">to</span>/transifex.jar
+</code></pre><p>, where <code>/path/to/</code> is the path to the directory you placed &quot;transifex.jar&quot;.</p>
+<p>Note that even though the tool uses UTF-8 internally, it&#39;s recommended to have your JVM&#39;s default character encoding set to UTF-8. If this isn&#39;t the case for your system, you can use:</p>
+<pre><code>java -jar -Dfile.<span class="hljs-keyword">encoding</span>=UTF8 /path/<span class="hljs-keyword">to</span>/transifex.jar
+</code></pre><p>For simplicity, the following commands will not include the <code>java -jar</code> part required to run the file.</p>
+<h3 id="usage">Usage</h3>
+<p>To use the tool on your app&#39;s Android Studio project, enter the root directory of your project from the command line.</p>
+<h4 id="help">Help</h4>
+<p><code>transifex</code>, <code>transifex -h</code>, <code>transifex --help</code></p>
+<p>Displays a help dialog with all the options and commands.</p>
+<p><code>transifex help &lt;command&gt;</code></p>
+<p>Get help for a particular command.</p>
+<h4 id="pushing">Pushing</h4>
+<p><code>transifex push -t &lt;transifex_token&gt; -s &lt;transifex_secret&gt; -m &lt;app_module_name&gt;</code></p>
+<p>Pushes the source strings of your app found in a module named &quot;app_module_name&quot;. The tool reads the <code>strings.xml</code> resource file found in the main source set of the specified module: <code>app_module_name/src/main/res/values/strings.xml</code>. It processes it and pushes the result to the Transifex CDS. </p>
+<p><code>transifex push -t &lt;transifex_token&gt; -s &lt;transifex_secret&gt; -f path/to/strings1.xml path2/to/strings2.xml</code></p>
+<p>If your app has a more complex string setup, you can specify one or more string resource files.</p>
+<p><code>transifex clear -t &lt;transifex_token&gt; -s &lt;transifex_secret&gt;</code></p>
+<p>Clears all existing resource content from CDS. This action will also remove existing localizations.</p>
+<h4 id="pulling">Pulling</h4>
+<p><code>transifex pull -t &lt;transifex_token&gt; -m &lt;app_module_name&gt; -l &lt;locale&gt;...</code></p>
+<p>Downloads the translations from Transifex CDS for the specified locales and stores them in txstrings.json files under the &quot;assets&quot; directory of the main source set of the specified app module: <code>app_module_name/src/main/assets/txnative</code>. The directory is created if needed. These files will be bundled inside your app and accessed by TxNative.</p>
+<p><code>transifex pull -t &lt;transifex_token&gt; -d &lt;directory&gt; -l &lt;locale&gt;...</code></p>
+<p>If you have a different setup, you can enter the path to your app&#39;s <code>assets</code> directory.</p>
+<h2 id="advanced-topics">Advanced topics</h2>
+<h3 id="disable-txnative-for-specific-strings">Disable TxNative for specific strings</h3>
+<p>There are cases where you don&#39;t want TxNative to interfere with string loading. For example, many apps have API keys or some configuration saved in non-translatable strings in their <code>strings.xml</code> file. A method like <code>getString()</code> is used to retreive the strings. If you are using the SDK&#39;s default missing policy, <code>SourceStringPolicy</code>, the expected string will be returned. If, however, you are using some other policy, the string may be altered and your app will not behave as expected. In such a case, make sure that you are using a non-wrapped context when loading such a string:</p>
+<pre><code class="lang-java">    <span class="hljs-selector-tag">getApplicationContext</span>()<span class="hljs-selector-class">.getString</span>(&lt;string_ID&gt;);
+</code></pre>
+<h3 id="txnative-and-3rd-party-libraries">TxNative and 3rd party libraries</h3>
+<p>Some libs may containt their own localized strings, views or activities. In such as case, you don&#39;t want TxNative to interfere with string loading. To accomplish that, make sure that you pass a non-wrapped context to the library&#39;s initialization method:</p>
+<pre><code class="lang-java">    SomeSDK.init(getApplicationContext())<span class="hljs-comment">;</span>
+</code></pre>
+<p>Note however that if a <code>View</code> provided by the library is used inside your app&#39;s activity, <code>TxNative</code> will be used during that view&#39;s inflation (if your activity is set up correctly). In that case, any library strings will not be found in TxNative translations and the result will depend on the missing policy used. <code>SourceStringPolicy</code> will return the source string provided by the library, which will probably be in English. Using, <code>AndroidMissingPolicy</code> will return the localized string using the library&#39;s localized string resources, as expected.</p>
+<h3 id="multiple-private-libraries">Multiple private libraries</h3>
+<p>If your app is split into libraries that contain localized strings, views or activities, you need to set up your project in the following way to take advantage of TxNatve in said libs.</p>
+<p>The strings included in the libraries have to be pushed to the CDS. You can push all of them at once using the push CLI command, e.g.
+<code>transifex push -t &lt;transifex_token&gt; -s &lt;transifex_secret&gt; -f path/to/strings1.xml path2/to/strings2.xml</code>. Alternatively, you can push each one separately as long as all strings reach the CDS resource used by the main app.</p>
+<p>If your lib has an initialization method, make sure that your main app passes the wrapped context:</p>
+<pre><code class="lang-java">    <span class="hljs-selector-tag">YourLib</span><span class="hljs-selector-class">.init</span>(<span class="hljs-selector-tag">TxNative</span><span class="hljs-selector-class">.wrap</span>(<span class="hljs-selector-tag">getApplicationContext</span>()));
+</code></pre>
+<p>The following string operations will result in string rendering through TxNative:</p>
+<ul>
+<li>The main app uses, in a layout or programmatically, the strings that the lib provides.</li>
+<li>The lib calls string resource methods such as <code>getString()</code>, e.g. for logging or something else, using the context that the main app passes through initialization.</li>
+<li>The lib has views that reference strings via layout or code and the main app displays these views in its activities.</li>
+</ul>
+<p>Note that if the main app starts any activity provided by the lib, string rendering won&#39;t go through TxNative. If you want to achieve this, you will have to integrate TxNative in the lib by following these steps: </p>
+<ol>
+<li>Use TxNative as a dependency in your library.</li>
+<li>Implement TxNative in the lib&#39;s activities.</li>
+<li>Note that TxNative should not be initialized inside the lib. The main app is responsible for this.</li>
+</ol>
+<h2 id="limitations">Limitations</h2>
+<p>Currently, the SDK does not support <a href="https://developer.android.com/guide/topics/resources/string-resource#StringArray">String arrays</a>. The command line tool will not upload them to Transifex and the SDK will not override the respective methods. String arrays presentation will work as normal using Android&#39;s localization system, which will require that you have them translated in the respective <code>strings.xml</code> files.</p>
+<p>Strings that are referenced in <a href="https://developer.android.com/guide/topics/ui/menus">menu</a> layout files will not be handled by the SDK. They will use Android&#39;s localization system as normal.</p>
+<p>Even though the SDK handles the strings referenced in a <a href="https://developer.android.com/reference/androidx/appcompat/widget/Toolbar"><code>Toolbar</code></a>, it won&#39;t handle strings referenced in an <a href="https://developer.android.com/reference/android/app/ActionBar"><code>ActionBar</code></a>. You will have to set them programmatically (e.g. by calling <a href="https://developer.android.com/reference/android/app/ActionBar#setTitle(java.lang.CharSequence"><code>setTitle()</code></a>)) to take advantage of the SDK. Otherwise, Android&#39;s localization system will be used.</p>
+<h2 id="license">License</h2>
+<p>Licensed under Apache License 2.0, see <a href="LICENSE">LICENSE</a> file.</p>
+</body></html>

--- a/TransifexNativeSDK/publish-helper.gradle
+++ b/TransifexNativeSDK/publish-helper.gradle
@@ -1,0 +1,121 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+// Initialize with environmental vars
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
+ext["signing.password"] = System.getenv('SIGNING_PASSWORD') ?: ''
+ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE') ?: ''
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME') ?: ''
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD') ?: ''
+
+// Override with local.properties if available
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    Properties p = new Properties()
+    p.load(new FileInputStream(secretPropsFile))
+    p.each { name, value ->
+        ext[name] = value
+    }
+}
+
+task androidJavadoc(type: Javadoc) {
+    if (plugins.hasPlugin('android-library')) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        android.libraryVariants.all { variant ->
+            if (variant.name == 'release') {
+                owner.classpath += variant.javaCompileProvider.get().classpath
+            }
+        }
+    }
+    else {
+        source = sourceSets.main.allJava
+        classpath += configurations.runtimeClasspath
+    }
+    exclude '**/R.html', '**/R.*.html', '**/index.html', '**/*.kt'
+    options.encoding 'utf-8'
+    options {
+        addStringOption 'docencoding', 'utf-8'
+        addStringOption 'charset', 'utf-8'
+        links 'https://docs.oracle.com/javase/7/docs/api/'
+        links 'https://d.android.com/reference'
+        links 'https://developer.android.com/reference/androidx/'
+    }
+}
+
+task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+    archiveClassifier.set('javadoc')
+    from androidJavadoc.destinationDir
+}
+
+task javaSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (plugins.hasPlugin('android-library')) {
+        from android.sourceSets.main.java.srcDirs
+    }
+    else {
+        from sourceSets.main.allSource
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called 'library'.
+            release(MavenPublication) {
+                if (plugins.hasPlugin('android-library')) {
+                    from components.release
+                }
+                else if (plugins.hasPlugin('java')) {
+                    from components.java
+                }
+
+                artifact androidJavadocJar
+                artifact javaSourcesJar
+
+                groupId rootProject.ext.pomGroupID
+                version rootProject.ext.sdkVersion
+                pom {
+                    name = artifactId
+                    description = 'Transifex Native library for Android'
+                    url = 'https://github.com/transifex/transifex-java'
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:https://github.com/transifex/transifex-java.git'
+                        url = 'https://github.com/transifex/transifex-java'
+                    }
+                    developers {
+                        developer {
+                            id = 'petrakeas'
+                            name = 'Petros Douvantzis'
+                            email = 'petrakeas@gmail.com'
+                        }
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = "sonatype"
+
+                def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
+                }
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/TransifexNativeSDK/settings.gradle
+++ b/TransifexNativeSDK/settings.gradle
@@ -2,4 +2,3 @@ include ':common'
 include ':clitool'
 include ':txsdk'
 include ':app'
-rootProject.name = "Transifex Application"

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        versionCode rootProject.ext.sdkVersionCode
+        versionName rootProject.ext.sdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -38,7 +38,6 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
     implementation 'io.github.inflationx:viewpump:2.0.3'
     api project(':common')
 
@@ -52,4 +51,18 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'com.google.truth:truth:1.1'
+}
+
+apply from: '../publish-helper.gradle'
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Specify custom artifactId if needed,
+                // otherwise it would use module's name by default.
+                artifactId = "txsdk"
+            }
+        }
+    }
 }

--- a/TransifexNativeSDK/txsdk/consumer-rules.pro
+++ b/TransifexNativeSDK/txsdk/consumer-rules.pro
@@ -1,0 +1,7 @@
+# Keep LocaleData inner classes as is, so that Gson works as expected
+-keep class com.transifex.common.LocaleData { *; }
+-keep class com.transifex.common.LocaleData$* { *; }
+
+# Keep class names for better log ouput
+-keepnames class com.transifex.txnative.**
+-keepnames class com.transifex.common.**

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
@@ -14,7 +14,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 /**
- * A class that extends {@link CDSHandler} by adding an async method that uses Android's AsyncTask.
+ * A class that extends {@link CDSHandler} by adding a method that can fetch translations
+ * asynchronously.
  *
  * @see CDSHandler
  */
@@ -53,7 +54,7 @@ public class CDSHandlerAndroid extends CDSHandler {
      */
     public CDSHandlerAndroid(@Nullable String[] localeCodes, @NonNull String token, @Nullable String secret, @NonNull String csdHost) {
         super(localeCodes, token, secret, csdHost);
-        mExecutor = Executors.newCachedThreadPool();
+        mExecutor = Executors.newSingleThreadExecutor();
     }
 
     /**

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -82,8 +82,8 @@ public class TxNative {
      * if tags exist in the source string. If disabled, a plain String is always returned. It's
      * disabled by default.
      * <p>
-     * Enable it, if your strings contain HTML tags using "<" and ">" characters. Leave it disabled
-     * if your strings are HTML-escaped such as the following:
+     * Enable it, if your strings contain HTML tags using {@code "<"} and  {@code ">"} characters.
+     * Leave it disabled if your strings are HTML-escaped such as the following:
      * <pre>{@code
      * <resources>
      *   <string name="welcome_messages">Hello, %1$s! You have &lt;b>%2$d new messages&lt;/b>.</string>
@@ -140,7 +140,7 @@ public class TxNative {
      *
      * @return The wrapped context.
      */
-    public static Context wrap(Context context) {
+    public static Context wrap(@NonNull Context context) {
         if (sNativeCore == null) {
             Log.e(TAG, "Wrapping failed because TxNative has not been initialized yet");
             return context;
@@ -162,7 +162,7 @@ public class TxNative {
      *
      * @return The wrapped context.
      */
-    public static Context generalWrap(Context context) {
+    public static Context generalWrap(@NonNull Context context) {
         if (sNativeCore == null) {
             Log.e(TAG, "Wrapping failed because TxNative has not been initialized yet");
             return context;

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxCache.java
@@ -2,8 +2,6 @@ package com.transifex.txnative.cache;
 
 import com.transifex.common.LocaleData;
 
-import java.util.Set;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxFileOutputCacheDecorator.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxFileOutputCacheDecorator.java
@@ -41,7 +41,17 @@ public class TxFileOutputCacheDecorator extends TxDecoratorCache {
         this(null, dstDirectory, internalCache);
     }
 
-    // for unit tests
+
+    /**
+     * Creates a new instance with a specific directory for storing the translations to the disk
+     * and an internal cache.
+     *
+     * @param executor The executor that will run the IO operations; if <code>null</code> is
+     *                 provided, {@link Executors#newSingleThreadExecutor()} is used.
+     * @param dstDirectory  The destination directory to write the translations to when the
+     *                      {@link #update(LocaleData.TranslationMap)} is called.
+     * @param internalCache The internal cache.
+     */
     protected TxFileOutputCacheDecorator(@Nullable Executor executor, @NonNull File dstDirectory,
                                          @NonNull TxCache internalCache) {
         super(internalCache);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/cache/TxUpdateFilterCache.java
@@ -42,27 +42,27 @@ public class TxUpdateFilterCache extends TxDecoratorCache {
      * </pre>
      * Here's an example on how to read the table above:
      * <ul>
-     *     <li>given a string with <code>key="c"</code></li>
-     *     <li>and a cache that has <code>"c"</code> as the stored value for this key (<code>"c" -> "c"</code>)</li>
-     *     <li>if an empty translation arrives for this string (<code>""</code>)
+     *     <li>given a string with {@code key="c"}</li>
+     *     <li>and a cache that has {@code "c"} as the stored value for this key ({@code "c" -> "c"})</li>
+     *     <li>if an empty translation arrives for this string ({@code ""})
      *     <ul>
-     *         <li>if policy is <code>REPLACE_ALL</code>, then the cache will be updated so that
-     *         (<code>"c" -> ""</code>)</li>
-     *         <li>in contrast to that, if policy is <code>UPDATE_USING_TRANSLATED</code>, then the
-     *         cache will stay as is (<code>"c" -> "c"</code>), because the new translation is
+     *         <li>if policy is {@code REPLACE_ALL}, then the cache will be updated so that
+     *         ({@code "c" -> ""})</li>
+     *         <li>in contrast to that, if policy is {@code UPDATE_USING_TRANSLATED}, then the
+     *         cache will stay as is ({@code "c" -> "c"}), because the new translation is
      *         empty</li>
      *     </ul>
      *     </li>
      * </ul>
-     * A <code>"-"</code> value means that the respective key does not exist. For example:
+     * A {@code "-"} value means that the respective key does not exist. For example:
      * <ul>
-     *     <li>given a string with <code>key="f"</code></li>
-     *     <li>and a cache that has no entry with <code>"f"</code> as a key</li>
-     *     <li>if a translation arrives for this string (<code>"f" -> "F"</code>)
+     *     <li>given a string with {@code key="f"}</li>
+     *     <li>and a cache that has no entry with {@code "f"} as a key</li>
+     *     <li>if a translation arrives for this string ({@code "f" -> "F"})
      *     <ul>
-     *         <li>if policy is <code>REPLACE_ALL</code>, then the cache will be updated by adding a
-     *         new entry so that (<code>"f" -> "F"</code>)</li>
-     *         <li>if policy is <code>UPDATE_USING_TRANSLATED</code>, then the same will happen,
+     *         <li>if policy is {@code REPLACE_ALL}, then the cache will be updated by adding a
+     *         new entry so that ({@code "f" -> "F"})</li>
+     *         <li>if policy is {@code UPDATE_USING_TRANSLATED}, then the same will happen,
      *         since the new translation is not empty</li>
      *     </ul>
      *     </li>

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicy.java
@@ -14,10 +14,9 @@ import androidx.annotation.StringRes;
  * <p>
  * <code>get("The quick brown fox");</code>
  * <p>
- * Returns:
+ * returns:
  * <p>
  * "Ťȟê ʠüıċǩ ƀȓøẁñ ƒøẋ"
- * </pre>
  */
 public class PseudoTranslationPolicy implements MissingPolicy {
 

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
@@ -16,12 +16,11 @@ import androidx.annotation.StringRes;
  * <p>
  * Example:
  * <p>
- * <code>new WrappedStringPolicy(">>", "<<").get("Click here");</code>
+ * {@code new WrappedStringPolicy(">>", "<<").get("Click here");}
  * <p>
  * Returns:
  * <p>
- * ">>Click here<<"
- * </pre>
+ * {@code ">>Click here<<"}
  */
 public class WrappedStringPolicy implements MissingPolicy{
 


### PR DESCRIPTION
The version number of common, txsdk and cli are defined in
the projet's build gradle as extra properties.

The cli gets its version number dynamically.

Created publish-helper.gradle file which is included
in the build.gradle of txsdk and common modules.
It is responsible for signing and publishing the modules to
Mavel repository along with their sources and javadoc.
The signing configuration and sonatype credentials can
be read from "local.properties" file or via environmental
variables.

Updated readme with gradle dependancy instructions.

Updated documentation to fix javadoc generation errors.

Added rules in txsdk consumer proguard file to solve
issues when the sdk is used in an app with R8/proguard
enabled.