### PR TITLE
Make Appcompat dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ implementation 'com.transifex.txnative:txsdk:0.x.y'
 Please replace `x` and `y` with the latest version numbers: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk)
 
 
-The library's minimum supported SDK is 18 (Android 4.3) and uses [appcompat](https://developer.android.com/jetpack/androidx/releases/appcompat) 1.2.0.
+The library's minimum supported SDK is 18 (Android 4.3) and is compatible with [Appcompat](https://developer.android.com/jetpack/androidx/releases/appcompat) 1.2.0. 
+
+The SDK does not add Appcompat as a dependency. It can work in apps that don't use Appcompat and in apps that use Appcompat 1.2.0.
 
 ### SDK configuration 
 
@@ -64,7 +66,7 @@ The language codes supported by Transifex can be found [here](https://www.transi
 
 In this example, the SDK uses its default cache, `TxStandardCache`, and missing policy, `SourceStringPolicy`. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.
 
-If you want to enable [multilingual support](https://developer.android.com/guide/topics/resources/multilingual-support.html) starting from Android N, place the supported app languages in your app's gradle file:
+Starting from Android N, Android has [multilingual support](https://developer.android.com/guide/topics/resources/multilingual-support.html): users can select more that one locale in Android's settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of `Appcompat`, it suffices to place the supported app languages in your app’s gradle file:
 
 ```gradle
 android {
@@ -75,6 +77,17 @@ android {
 
     }
 ```
+
+If your app doesn't use `Appcompat`, you should define a dummy string in your default, unlocalized `strings.xml` file and place a `strings.xml` file for each supported locale and define the same string there. For example:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dummy">dummy</string>
+</resources>
+```
+
+This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user. If you don't do that, Android will always pick the first locale selected by the user.
 
 ### Context Wrapping 
 
@@ -194,7 +207,7 @@ If you want to have your memory cache updated with the new translations when `fe
 
 ### Sample app
 
-You can see the SDK used and configured in more advanced ways in the provided sample app.
+You can see the SDK used and configured in more advanced ways in the provided sample app of this repo. You can also check out a simpler app at the [Transifex Native repo](https://github.com/transifex/transifex-native-sandbox).
 
 ## Transifex Command Line Tool
 
@@ -270,7 +283,7 @@ If you have a different setup, you can enter the path to your app's `assets` dir
 
 ### Disable TxNative for specific strings
 
-There are cases where you don't want TxNative to interfere with string loading. For example, many apps have API keys or some configuration saved in non-translatable strings in their `strings.xml` file. A method like `getString()` is used to retreive the strings. If you are using the SDK's default missing policy, `SourceStringPolicy`, the expected string will be returned. If, however, you are using some other policy, the string may be altered and your app will not behave as expected. In such a case, make sure that you are using a non-wrapped context when loading such a string:
+There are cases where you don't want TxNative to interfere with string loading. For example, many apps have API keys or some configuration saved in non-translatable strings in their `strings.xml` file. A method like `getString()` is used to retrieve the strings. If you are using the SDK's default missing policy, `SourceStringPolicy`, the expected string will be returned. If, however, you are using some other policy, the string may be altered and your app will not behave as expected. In such a case, make sure that you are using a non-wrapped context when loading such a string:
 
 ```java
     getApplicationContext().getString(<string_ID>);
@@ -278,7 +291,7 @@ There are cases where you don't want TxNative to interfere with string loading. 
 
 ### TxNative and 3rd party libraries
 
-Some libs may containt their own localized strings, views or activities. In such as case, you don't want TxNative to interfere with string loading. To accomplish that, make sure that you pass a non-wrapped context to the library's initialization method:
+Some libs may contain their own localized strings, views or activities. In such as case, you don't want TxNative to interfere with string loading. To accomplish that, make sure that you pass a non-wrapped context to the library's initialization method:
 
 ```java
     SomeSDK.init(getApplicationContext());

--- a/TransifexNativeSDK/app/build.gradle
+++ b/TransifexNativeSDK/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     testImplementation 'junit:junit:4.13.2'

--- a/TransifexNativeSDK/build.gradle
+++ b/TransifexNativeSDK/build.gradle
@@ -1,7 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.versions = [
+            'kotlin' : '1.4.32',
+            'androidXAnnotation' : '1.2.0'
+    ]
     ext {
-        kotlin_version = '1.4.10'
+        sdkVersionCode = 1                      // version code for txsdk
+        sdkVersion = '0.1.0'                    // version for txsdk and common
+        pomGroupID = "com.transifex.txnative"   // pom group id for txsdk and common
+
+        cliVersion = '0.1.0'                    // clitool version
     }
     repositories {
         google()
@@ -9,7 +17,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,14 +26,6 @@ buildscript {
 
 plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
-}
-
-ext {
-    sdkVersionCode = 1                      // version code for txsdk
-    sdkVersion = '0.1.0'                    // version for txsdk and common
-    pomGroupID = "com.transifex.txnative"   // pom group id for txsdk and common
-
-    cliVersion = '0.1.0'                    // clitool version
 }
 
 allprojects {
@@ -101,7 +101,7 @@ gradle.projectsEvaluated {
             subproject.name == 'txsdk' || subproject.name == 'common'
         }
 
-        // Merge properties of androidJavadoc tasks (which is supported by both subprojects)
+        // Merge the properties of the androidJavadoc tasks of the subprojects
         source = projectSet.androidJavadoc.source
         classpath = project.files(projectSet.androidJavadoc.classpath)
         excludes = projectSet.androidJavadoc.excludes.flatten().unique()

--- a/TransifexNativeSDK/clitool/build.gradle
+++ b/TransifexNativeSDK/clitool/build.gradle
@@ -39,11 +39,12 @@ tasks.withType(Test) {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
+    compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     implementation 'org.jdom:jdom:2.0.2'
     implementation 'info.picocli:picocli:4.6.1'
     implementation project(':common')
 
+    testCompileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'

--- a/TransifexNativeSDK/common/build.gradle
+++ b/TransifexNativeSDK/common/build.gradle
@@ -16,10 +16,11 @@ tasks.withType(Test) {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
+    compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'net.moznion:uribuilder-tiny:2.7.1'
 
+    testCompileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'

--- a/TransifexNativeSDK/publish-helper.gradle
+++ b/TransifexNativeSDK/publish-helper.gradle
@@ -14,6 +14,7 @@ task androidJavadoc(type: Javadoc) {
     else {
         source = sourceSets.main.allJava
         classpath += configurations.runtimeClasspath
+        classpath += configurations.compileClasspath
     }
     exclude '**/R.html', '**/R.*.html', '**/index.html', '**/*.kt'
     options.encoding 'utf-8'

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -34,20 +34,29 @@ tasks.withType(Test) {
     systemProperty "file.encoding", "UTF-8"
 }
 
+configurations.all  {
+    resolutionStrategy {
+        force "androidx.annotation:annotation:$versions.androidXAnnotation"
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
+    compileOnly 'androidx.appcompat:appcompat:1.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'io.github.inflationx:viewpump:2.0.3'
     api project(':common')
 
-    testImplementation 'junit:junit:4.13.1'
+    testCompileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.4'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'org.mockito:mockito-core:3.8.0'
 
+    androidTestCompileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'com.google.truth:truth:1.1'

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -20,7 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
-import androidx.core.text.HtmlCompat;
+
+import static android.text.Html.FROM_HTML_MODE_LEGACY;
 
 /**
  * The main class of the framework, responsible for orchestrating all functionality.
@@ -353,7 +354,7 @@ public class NativeCore {
     @NonNull CharSequence getSpannedString(@NonNull String string) {
         if (mSupportSpannableEnabled) {
             // If a span was found, return a "Spanned" object. Otherwise, return "String".
-            Spanned spanned = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_LEGACY);
+            Spanned spanned = Utils.fromHtml(string, FROM_HTML_MODE_LEGACY);
             if (spanned.getSpans(0, spanned.length(), Object.class).length != 0) {
                 return new SpannedString(spanned);
             }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxInterceptor.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxInterceptor.java
@@ -59,7 +59,7 @@ class TxInterceptor implements Interceptor {
             if (view instanceof TextView) {
                 mTextViewTransformer.transform(context, view, attrs);
             }
-            else if (view instanceof androidx.appcompat.widget.Toolbar) {
+            else if (Utils.isAppcompatPresent() && view instanceof androidx.appcompat.widget.Toolbar) {
                 mSupportToolbarTransformer.transform(context, view, attrs);
             }
             else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && view instanceof Toolbar) {

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
@@ -5,13 +5,11 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Build;
+import android.text.Html;
+import android.text.Spanned;
 import android.util.AttributeSet;
 import android.util.Log;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Locale;
 
 import androidx.annotation.AttrRes;
@@ -21,6 +19,12 @@ import androidx.annotation.StringRes;
 public class Utils {
 
     private static final String TAG = Utils.class.getSimpleName();
+
+    private static final boolean sIsAppcompatPresent;
+
+    static {
+        sIsAppcompatPresent = isClassPresent("androidx.appcompat.widget.Toolbar");
+    }
 
     /**
      * Returns the string resource id that this attributeId is resolving to under the provided
@@ -125,5 +129,39 @@ public class Utils {
 
     public static boolean equals(Object a, Object b) {
         return (a == b) || (a != null && a.equals(b));
+    }
+
+    /**
+     * Invokes {@link Html#fromHtml(String, int)} on API 24 and newer, otherwise {@code flags} are
+     * ignored and {@link Html#fromHtml(String)} is used.
+     */
+    @SuppressWarnings("deprecation")
+    @NonNull
+    public static Spanned fromHtml(@NonNull String source, int flags) {
+        // taken from androidx.core.text
+        if (Build.VERSION.SDK_INT >= 24) {
+            return Html.fromHtml(source, flags);
+        }
+        return Html.fromHtml(source);
+    }
+
+    /**
+     * Checks, using reflection, if the provided class is available at runtime.
+     */
+    public static boolean isClassPresent(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (Throwable ex) {
+            // Class or one of its dependencies is not present...
+            return false;
+        }
+    }
+
+    /**
+     * Checks if <code>Androidx.appcompat</code> classes are available at runtime.
+     */
+    public static boolean isAppcompatPresent() {
+        return sIsAppcompatPresent;
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/transformers/ToolbarTransformer.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/transformers/ToolbarTransformer.java
@@ -24,7 +24,10 @@ public class ToolbarTransformer extends ViewTransformer {
         CharSequence xa = toolbar.getTitle();
 
         int titleResourceId = Utils.getStringResourceId(context, attrs, android.R.attr.title);
-        int titleCompatResourceId = Utils.getStringResourceId(context, attrs, androidx.appcompat.R.attr.title);
+        int titleCompatResourceId = 0;
+        if (Utils.isAppcompatPresent()) {
+            titleCompatResourceId = Utils.getStringResourceId(context, attrs, androidx.appcompat.R.attr.title);
+        }
         if (titleResourceId != 0) {
             toolbar.setTitle(titleResourceId);
         }
@@ -34,7 +37,10 @@ public class ToolbarTransformer extends ViewTransformer {
 
 
         int subtitleResourceId = Utils.getStringResourceId(context, attrs, android.R.attr.subtitle);
-        int subtitleCompatResourceId = Utils.getStringResourceId(context, attrs, androidx.appcompat.R.attr.subtitle);
+        int subtitleCompatResourceId = 0;
+        if (Utils.isAppcompatPresent()) {
+            subtitleCompatResourceId = Utils.getStringResourceId(context, attrs, androidx.appcompat.R.attr.subtitle);
+        }
         if (subtitleResourceId != 0) {
             toolbar.setSubtitle(subtitleResourceId);
         }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
@@ -18,9 +18,9 @@ import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
 
-import androidx.core.text.HtmlCompat;
 import androidx.test.core.app.ApplicationProvider;
 
+import static android.text.Html.FROM_HTML_MODE_LEGACY;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -246,7 +246,7 @@ public class NativeCoreTest {
 
         assertThat(string).isInstanceOf(String.class);
 
-        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
+        string = Utils.fromHtml(string.toString(), FROM_HTML_MODE_LEGACY);
 
         CharSequence styledPart = null;
 
@@ -298,7 +298,7 @@ public class NativeCoreTest {
 
         assertThat(string).isInstanceOf(String.class);
 
-        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
+        string = Utils.fromHtml(string.toString(), FROM_HTML_MODE_LEGACY);
 
         CharSequence styledPart = null;
 
@@ -332,7 +332,7 @@ public class NativeCoreTest {
 
         assertThat(string).isInstanceOf(String.class);
 
-        string = HtmlCompat.fromHtml(string.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY);
+        string = Utils.fromHtml(string.toString(), FROM_HTML_MODE_LEGACY);
 
         CharSequence styledPart = null;
 

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
@@ -5,13 +5,14 @@ import android.text.Spanned;
 import android.text.SpannedString;
 import android.text.style.StyleSpan;
 
+import com.transifex.txnative.Utils;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import androidx.core.text.HtmlCompat;
-
+import static android.text.Html.FROM_HTML_MODE_LEGACY;
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
@@ -72,7 +73,7 @@ public class WrappedStringPolicyTest {
         // Test that a spanned source string keeps its spans after being processed
 
         WrappedStringPolicy policy = new WrappedStringPolicy("start! ", " !end");
-        CharSequence sourceString = HtmlCompat.fromHtml("The quick <b>brown</b> fox", HtmlCompat.FROM_HTML_MODE_LEGACY);
+        CharSequence sourceString = Utils.fromHtml("The quick <b>brown</b> fox", FROM_HTML_MODE_LEGACY);
         CharSequence translated = policy.wrapString(sourceString);
 
         assertThat(translated).isInstanceOf(Spanned.class);


### PR DESCRIPTION
txsdk's build.gradle declared an "implementation" dependency to
'androidx.appcompat:appcompat:1.2.0'. The dependency is now changed to
"compile-only". This way, we are not adding Appcompat to an app that is not
already using Appcompat.

Special care was taken for accessing  Appcompat methods and classes, as
doing so in an app that is not using Appcompat will result in a crash, since the
Appcompat classes will not be found at runtime. Utils#isAppcompatPresent()
is used before accessing an Appcompat class.

Removing Appcompat also affects multilingual support since Appcompat adds some
strings which are localized in lots of locales. Readme was updated with extended
instructions in case Appcompat is not used.

'androidx.annotation:annotation' dependency has been changed from "implementation" to
"compileOnly", as it is only needed at compile time (and when building the javadoc).
Since "compileOnly" dependencies are not inherited by the test sourcesets, it had to be
redeclared using "testCompileOnly".