### PR TITLE
Change step order in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,6 @@ jobs:
         asset_name: 'transifex.jar'
         asset_path: TransifexNativeSDK/clitool/build/libs/transifex.jar
         asset_content_type: application/java-archive
-        
-    - name: Build and publish SDK to Maven
-      working-directory: ./TransifexNativeSDK
-      env:
-        SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        PGP_KEY_CONTENTS: ${{ secrets.PGP_KEY_CONTENTS }}
-      run: |
-        ./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
-        ./gradlew cleanTmp
       
     - name: Generate Javadoc
       if:  ${{ !endsWith(github.event.release.tag_name, 'SNAPSHOT') }}
@@ -74,6 +62,18 @@ jobs:
         branch: documentation
         folder: TransifexNativeSDK/build/docs/javadoc
         target-folder: docs
+        
+    - name: Build and publish SDK to Maven
+      working-directory: ./TransifexNativeSDK
+      env:
+        SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        PGP_KEY_CONTENTS: ${{ secrets.PGP_KEY_CONTENTS }}
+      run: |
+        ./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+        ./gradlew cleanTmp
     
     - name: Cleanup Gradle Cache
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/TransifexNativeSDK/doc/readme.html
+++ b/TransifexNativeSDK/doc/readme.html
@@ -18,7 +18,8 @@ advantage of the features that Transifex Native offers, such as OTA translations
 <pre><code class="lang-groovy"><span class="hljs-keyword">implementation</span> <span class="hljs-string">'com.transifex.txnative:txsdk:0.x.y'</span>
 </code></pre>
 <p>Please replace <code>x</code> and <code>y</code> with the latest version numbers: <a href="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk"><img src="https://maven-badges.herokuapp.com/maven-central/com.transifex.txnative/txsdk/badge.svg" alt="Maven Central"></a></p>
-<p>The library&#39;s minimum supported SDK is 18 (Android 4.3) and uses <a href="https://developer.android.com/jetpack/androidx/releases/appcompat">appcompat</a> 1.2.0.</p>
+<p>The library&#39;s minimum supported SDK is 18 (Android 4.3) and is compatible with <a href="https://developer.android.com/jetpack/androidx/releases/appcompat">Appcompat</a> 1.2.0. </p>
+<p>The SDK does not add Appcompat as a dependency. It can work in apps that don&#39;t use Appcompat and in apps that use Appcompat 1.2.0.</p>
 <h3 id="sdk-configuration">SDK configuration</h3>
 <p>Configure the SDK in your <code>Application</code> class. </p>
 <p>The language codes supported by Transifex can be found <a href="https://www.transifex.com/explore/languages/">here</a>. They can either use 2 characters, such as <code>es</code>, or specify the regional code as well, such as <code>es_ES</code>. Keep in mind that in the sample code below you will have to replace <code>&lt;transifex_token&gt;</code> with the actual token that is associated with your Transifex project and resource.</p>
@@ -47,7 +48,7 @@ advantage of the features that Transifex Native offers, such as OTA translations
      }
 </code></pre>
 <p>In this example, the SDK uses its default cache, <code>TxStandardCache</code>, and missing policy, <code>SourceStringPolicy</code>. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.</p>
-<p>If you want to enable <a href="https://developer.android.com/guide/topics/resources/multilingual-support.html">multilingual support</a> starting from Android N, place the supported app languages in your app&#39;s gradle file:</p>
+<p>Starting from Android N, Android has <a href="https://developer.android.com/guide/topics/resources/multilingual-support.html">multilingual support</a>: users can select more that one locale in Android&#39;s settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of <code>Appcompat</code>, it suffices to place the supported app languages in your app’s gradle file:</p>
 <pre><code class="lang-gradle"><span class="hljs-class">android </span>{
     ...
     <span class="hljs-class">defaultConfig </span>{
@@ -56,6 +57,12 @@ advantage of the features that Transifex Native offers, such as OTA translations
 
     }
 </code></pre>
+<p>If your app doesn&#39;t use <code>Appcompat</code>, you should define a dummy string in your default, unlocalized <code>strings.xml</code> file and place a <code>strings.xml</code> file for each supported locale and define the same string there. For example:</p>
+<pre><code><span class="php"><span class="hljs-meta">&lt;?</span>xml version=<span class="hljs-string">"1.0"</span> encoding=<span class="hljs-string">"utf-8"</span><span class="hljs-meta">?&gt;</span></span>
+<span class="hljs-tag">&lt;<span class="hljs-name">resources</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"dummy"</span>&gt;</span>dummy<span class="hljs-tag">&lt;/<span class="hljs-name">string</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">resources</span>&gt;</span>
+</code></pre><p>This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user. If you don&#39;t do that, Android will always pick the first locale selected by the user.</p>
 <h3 id="context-wrapping">Context Wrapping</h3>
 <p>The SDK&#39;s functionality is enabled by wrapping the context, so that all string resource related methods, such a <a href="https://developer.android.com/reference/android/content/res/Resources#getString(int,%20java.lang.Object..."><code>getString()</code></a>), <a href="https://developer.android.com/reference/android/content/res/Resources#getText(int"><code>getText()</code></a>), flow through the SDK.</p>
 <p>To enable context wrapping in your activity, use the following code or have your activity extend a base class:</p>
@@ -144,7 +151,7 @@ to the <a href="https://github.com/transifex/transifex-delivery/#invalidate-cach
         );
 </code></pre><p>If you want to have your memory cache updated with the new translations when <code>fetchTranslations()</code> is called, you can remove the <code>TXReadonlyCacheDecorator</code>.</p>
 <h3 id="sample-app">Sample app</h3>
-<p>You can see the SDK used and configured in more advanced ways in the provided sample app.</p>
+<p>You can see the SDK used and configured in more advanced ways in the provided sample app of this repo. You can also check out a simpler app at the <a href="https://github.com/transifex/transifex-native-sandbox">Transifex Native repo</a>.</p>
 <h2 id="transifex-command-line-tool">Transifex Command Line Tool</h2>
 <p>Transifex Command Line Tool is a command line tool that can assist developers in pushing the source strings of an Android app to Transifex.</p>
 <h3 id="building">Building</h3>
@@ -180,11 +187,11 @@ to the <a href="https://github.com/transifex/transifex-delivery/#invalidate-cach
 <p>If you have a different setup, you can enter the path to your app&#39;s <code>assets</code> directory.</p>
 <h2 id="advanced-topics">Advanced topics</h2>
 <h3 id="disable-txnative-for-specific-strings">Disable TxNative for specific strings</h3>
-<p>There are cases where you don&#39;t want TxNative to interfere with string loading. For example, many apps have API keys or some configuration saved in non-translatable strings in their <code>strings.xml</code> file. A method like <code>getString()</code> is used to retreive the strings. If you are using the SDK&#39;s default missing policy, <code>SourceStringPolicy</code>, the expected string will be returned. If, however, you are using some other policy, the string may be altered and your app will not behave as expected. In such a case, make sure that you are using a non-wrapped context when loading such a string:</p>
+<p>There are cases where you don&#39;t want TxNative to interfere with string loading. For example, many apps have API keys or some configuration saved in non-translatable strings in their <code>strings.xml</code> file. A method like <code>getString()</code> is used to retrieve the strings. If you are using the SDK&#39;s default missing policy, <code>SourceStringPolicy</code>, the expected string will be returned. If, however, you are using some other policy, the string may be altered and your app will not behave as expected. In such a case, make sure that you are using a non-wrapped context when loading such a string:</p>
 <pre><code class="lang-java">    <span class="hljs-selector-tag">getApplicationContext</span>()<span class="hljs-selector-class">.getString</span>(&lt;string_ID&gt;);
 </code></pre>
 <h3 id="txnative-and-3rd-party-libraries">TxNative and 3rd party libraries</h3>
-<p>Some libs may containt their own localized strings, views or activities. In such as case, you don&#39;t want TxNative to interfere with string loading. To accomplish that, make sure that you pass a non-wrapped context to the library&#39;s initialization method:</p>
+<p>Some libs may contain their own localized strings, views or activities. In such as case, you don&#39;t want TxNative to interfere with string loading. To accomplish that, make sure that you pass a non-wrapped context to the library&#39;s initialization method:</p>
 <pre><code class="lang-java">    SomeSDK.init(getApplicationContext())<span class="hljs-comment">;</span>
 </code></pre>
 <p>Note however that if a <code>View</code> provided by the library is used inside your app&#39;s activity, <code>TxNative</code> will be used during that view&#39;s inflation (if your activity is set up correctly). In that case, any library strings will not be found in TxNative translations and the result will depend on the missing policy used. <code>SourceStringPolicy</code> will return the source string provided by the library, which will probably be in English. Using, <code>AndroidMissingPolicy</code> will return the localized string using the library&#39;s localized string resources, as expected.</p>


### PR DESCRIPTION
The step that publishes the SDK to Maven can fail for network
or other reasons. At the same time, the javadoc deployment to
Github pages is deterministic.

This is why, publishing to Maven was placed as a last step
in the  workflow. This way, even if it fails, we are certain
that the other steps succeeded. We can always
publish to Maven manually.

Updated readme.html to reflect the latest readme.md