### PR TITLE
Add x-native-sdk header in CDSHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ android {
 
 If your app doesn't use `Appcompat`, you should define a dummy string in your default, unlocalized `strings.xml` file and place a `strings.xml` file for each supported locale and define the same string there. For example:
 
-```
+```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="dummy">dummy</string>
@@ -188,7 +188,7 @@ The SDK allows you to implement your own cache from scratch by implementing the 
 
 In order to achieve that, you can create a a method that returns a `TxCache` instance, just like in the `TxStandardCache.getCache()` case. For example, the standard cache is created as follows:
 
-```
+```java
 return new TxFileOutputCacheDecorator(
                 <cached Translations Directory>,
                 new TXReadonlyCacheDecorator(

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -1,5 +1,6 @@
 package com.transifex.clitool;
 
+import com.transifex.common.BuildProperties;
 import com.transifex.common.CDSHandler;
 import com.transifex.common.LocaleData;
 import com.transifex.common.TranslationMapStorage;
@@ -43,9 +44,8 @@ public class MainClass {
     public static class VersionProvider implements CommandLine.IVersionProvider {
 
         @Override
-        public String[] getVersion() throws Exception {
-            // Get the version that was specified in the jar gradle task
-            return new String[]{VersionProvider.class.getPackage().getImplementationVersion()};
+        public String[] getVersion() {
+            return new String[]{BuildProperties.getCLIVersion()};
         }
     }
 

--- a/TransifexNativeSDK/common/build.gradle
+++ b/TransifexNativeSDK/common/build.gradle
@@ -27,4 +27,20 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.6'
 }
 
+// Generate a BuildProperties Java class
+task generateJava {
+    ext.outputDir = "$buildDir/generated/java"
+    doLast {
+        mkdir "$outputDir/com/transifex/common"
+        file("$outputDir/com/transifex/common/BuildProperties.java").text =
+                """|package com.transifex.common;
+               |public class BuildProperties {
+               |    public static String getSDKVersion() { return "${rootProject.ext.sdkVersion}"; }
+               |    public static String getCLIVersion() { return "${rootProject.ext.cliVersion}"; }
+               |}""".stripMargin()
+    }
+}
+compileJava.dependsOn generateJava
+sourceSets.main.java.srcDir generateJava.outputDir
+
 apply from: '../publish-helper.gradle'

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/CDSHandler.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/CDSHandler.java
@@ -400,6 +400,8 @@ public class CDSHandler {
             connection.addRequestProperty("Authorization", "Bearer " + mToken);
         }
 
+        connection.addRequestProperty("x-native-sdk", "mobile/android/" + BuildProperties.getSDKVersion());
+
         if (etag != null) {
             connection.addRequestProperty("If-None-Match", etag);
         }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/CDSHandlerTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/CDSHandlerTest.java
@@ -274,6 +274,7 @@ public class CDSHandlerTest {
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
         assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
         assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json; charset=utf-8");
+        assertThat(recordedRequest.getHeader("x-native-sdk")).isEqualTo("mobile/android/" + BuildProperties.getSDKVersion());
     }
 
     @Test
@@ -327,6 +328,7 @@ public class CDSHandlerTest {
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
         assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
         assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json; charset=utf-8");
+        assertThat(recordedRequest.getHeader("x-native-sdk")).isEqualTo("mobile/android/" + BuildProperties.getSDKVersion());
     }
 
     @Test
@@ -357,6 +359,7 @@ public class CDSHandlerTest {
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
         assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
         assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json; charset=utf-8");
+        assertThat(recordedRequest.getHeader("x-native-sdk")).isEqualTo("mobile/android/" + BuildProperties.getSDKVersion());
 
         assertThat(map).isNotNull();
         assertThat(map.getLocales()).containsExactly("el", "es");
@@ -489,6 +492,7 @@ public class CDSHandlerTest {
         assertThat(recordedRequest.getMethod()).isEqualTo("POST");
         assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Bearer token:secret");
         assertThat(recordedRequest.getHeader("Content-Type")).isEqualTo("application/json; charset=utf-8");
+        assertThat(recordedRequest.getHeader("x-native-sdk")).isEqualTo("mobile/android/" + BuildProperties.getSDKVersion());
 
         String postBody = recordedRequest.getBody().readUtf8();
         Gson gson = new Gson();


### PR DESCRIPTION
The build.gradle of "common" module can now generate  a
BuildProperites.java file that exposes some gradle properties
to Java.

BuildProperties#getSDKVersion() is used in CDSHandler#addHeaders() so that
"x-native-sdk" -> "mobile/android/{TXNative.version}" header is added when pushing
or pulling strings.

CLI used to get the CLI version from the "Implementation-Version" property of the jar
file. We now use BuildProperties#getCLIVersion() to get the version.