### PR TITLE
Add CLI option to append tags on push

### DIFF
--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -116,6 +116,11 @@ public class MainClass {
             File[] files;
         }
 
+        @Option(names = {"-a", "--append-tags"}, arity = "0..",
+                description = "Append custom tags to the pushed source strings.",
+                paramLabel = "<tag>")
+        String[] tags;
+
         @Option(names = {"-p", "--purge"},
                 description = "If set, the entire resource content is replaced by the pushed content " +
                         "of this request. Otherwise, source content of this request is appended to " +
@@ -162,6 +167,13 @@ public class MainClass {
                 } catch (Exception e) {
                     System.out.println("Error parsing string file: " + e.getMessage());
                     return 1;
+                }
+            }
+
+            // Append custom tags
+            if (tags != null && tags.length != 0) {
+                for (LocaleData.StringInfo stringInfo : sourceStringMap.values()) {
+                    stringInfo.appendTags(tags);
                 }
             }
 

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
@@ -145,8 +145,8 @@ public class MainClassTest {
 
         server.setDispatcher(getPostDispatcher());
 
-        String args = String.format("-u %s push -t token -s secret -f %s", baseUrl,
-                "../txsdk/src/test/res/values/strings.xml");
+        String args = String.format("-u %s push -t token -s secret -f %s -a %s -a %s", baseUrl,
+                "../txsdk/src/test/res/values/strings.xml", "some_tag", "another_tag");
         int returnValue = MainClass.testMain(args);
 
         assertThat(returnValue).isEqualTo(0);
@@ -164,6 +164,11 @@ public class MainClassTest {
         assertThat(parsedPostData.data.keySet()).containsExactly("tx_test_key", "tx_plural_test_key").inOrder();
         assertThat(parsedPostData.data.get("tx_test_key").string).isEqualTo("test");
         assertThat(parsedPostData.data.get("tx_plural_test_key").string).isEqualTo("{cnt, plural, one {car} two {car 2} other {cars}}");
+
+        // Check appended tags
+        assertThat(parsedPostData.data.get("tx_test_key").meta.tags).isNotNull();
+        assertThat(parsedPostData.data.get("tx_test_key").meta.tags).containsExactly("some_tag", "another_tag");
+        assertThat(parsedPostData.data.get("tx_plural_test_key").meta.tags).containsExactly("some_tag", "another_tag");
     }
 
     @Test

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -2,8 +2,10 @@ package com.transifex.common;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -26,12 +28,64 @@ public class LocaleData {
             this.string = string;
         }
 
+        public StringInfo(@NonNull String string, @Nullable Meta meta) {
+            this.string = string;
+            this.meta = meta;
+        }
+
         public final String string;
+
+        public static class Meta {
+            public Set<String> tags;
+
+            @Override
+            @NonNull
+            public String toString() {
+                return "{tags=" + tags + "}";
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+
+                Meta meta = (Meta) o;
+
+                return tags != null ? tags.equals(meta.tags) : meta.tags == null;
+            }
+
+            @Override
+            public int hashCode() {
+                return tags != null ? tags.hashCode() : 0;
+            }
+        }
+
+        public Meta meta;
+
+        public void appendTags(@NonNull String[] tags) {
+            if (tags == null || tags.length == 0) {
+                return;
+            }
+            if (meta == null) {
+                meta = new Meta();
+            }
+            if (meta.tags == null) {
+                meta.tags = new LinkedHashSet<>(Arrays.asList(tags));
+            }
+            else {
+                meta.tags.addAll(Arrays.asList(tags));
+            }
+        }
 
         @Override
         @NonNull
         public String toString() {
-            return "{" + "string='" + string + '\'' + '}';
+            if (meta == null) {
+                return "{" + "string='" + string + '\'' + '}';
+            }
+            else {
+                return "{" + "string='" + string + '\'' + ", meta=" + meta + '}';
+            }
         }
 
         @Override
@@ -39,13 +93,16 @@ public class LocaleData {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             StringInfo that = (StringInfo) o;
-            return (string == that.string) || (string != null && string.equals(that.string));
+
+            if (string != null ? !string.equals(that.string) : that.string != null) return false;
+            return meta != null ? meta.equals(that.meta) : that.meta == null;
         }
 
         @Override
         public int hashCode() {
             if (string == null)
                 return 0;
+            // We don't care about meta
             return string.hashCode();
         }
     }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
@@ -2,7 +2,9 @@ package com.transifex.common;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -47,6 +49,13 @@ public class LocaleDataTest {
         LocaleData.StringInfo a2 = new LocaleData.StringInfo("a");
 
         assertThat(a.hashCode()).isEqualTo(a2.hashCode());
+
+        // Meta should not affect the hash code
+        LocaleData.StringInfo.Meta meta = new LocaleData.StringInfo.Meta();
+        meta.tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+        LocaleData.StringInfo c = new LocaleData.StringInfo("a", meta);
+
+        assertThat(c.hashCode()).isEqualTo(a.hashCode());
     }
 
     @Test
@@ -57,6 +66,27 @@ public class LocaleDataTest {
 
         assertThat(a).isEqualTo(a2);
         assertThat(a).isNotEqualTo(b);
+
+        LocaleData.StringInfo.Meta meta = new LocaleData.StringInfo.Meta();
+        meta.tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+        LocaleData.StringInfo c = new LocaleData.StringInfo("a", meta);
+        LocaleData.StringInfo c2 = new LocaleData.StringInfo("a", meta);
+
+        assertThat(c).isEqualTo(c2);
+        assertThat(c).isNotEqualTo(a);
+    }
+
+    @Test
+    public void testStringInfoAppendTags() {
+        LocaleData.StringInfo a = new LocaleData.StringInfo("a");
+        a.appendTags(new String[]{"tag1", "tag2"});
+
+        assertThat(a.meta).isNotNull();
+        assertThat(a.meta.tags).containsExactly("tag1", "tag2");
+
+        // Check that new tags are added and that each tag is listed once
+        a.appendTags(new String[]{"tag2", "tag3"});
+        assertThat(a.meta.tags).containsExactly("tag1", "tag2", "tag3");
     }
 
     @Test


### PR DESCRIPTION
LocaleData.StringInfo class has now a "Meta" subclass
that contains "tags" in the form of a string array according to
the spec: https://github.com/transifex/transifex-delivery/#push-content

The following methods have been updated to take the "meta" field into account:
equals(), toString()

Added "--append-tags" option in CLI's MainClass. It is optional and can accept
zero to multiple tags. The tags are appended to the parsed strings.