### PR TITLE
Fetch source locale string content

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ If you want to disable the SDK functionality, don't initialize it and don't call
 ### Fetching translations
 
 As soon as `fetchTranslations()` is called, the SDK will attempt to download the 
-translations for all locales - except for the source locale - that are defined in the 
-initialization of `TxNative`. 
+translations for the locales that are defined in the initialization of `TxNative` and 
+the source locale strings.
 
 The `fetchTranslations()` method in the previous example is called as soon as the application launches, but that's not required. Depending on the application, the developer might choose to call that method whenever it is most appropriate (for example, each time the application is brought to the foreground or when the internet connectivity is established).
 

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -276,7 +276,7 @@ public class MainClass {
 
         @Option(names = {"-l", "--locales"}, arity = "1..", required = true,
                 description = "A list of the target locales to download from CDS. The " +
-                        "source locale should not be included.", paramLabel = "<locale>")
+                        "source locale can also be included.", paramLabel = "<locale>")
         String[] translatedLocales;
 
         @Override

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/CDSHandler.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/CDSHandler.java
@@ -97,8 +97,8 @@ public class CDSHandler {
     /**
      * Creates a CDSHandler instance.
      *
-     * @param localeCodes An array of locale codes that can be downloaded from CDS. It should not
-     *                    include the source language.
+     * @param localeCodes An array of locale codes that can be downloaded from CDS. The source
+     *                    locale can also be included.
      * @param token The API token to use for connecting to the CDS.
      * @param secret The API secret to use for connecting to the CDS.
      * @param csdHost The host of the Content Delivery Service.

--- a/TransifexNativeSDK/doc/readme.html
+++ b/TransifexNativeSDK/doc/readme.html
@@ -58,11 +58,12 @@ advantage of the features that Transifex Native offers, such as OTA translations
     }
 </code></pre>
 <p>If your app doesn&#39;t use <code>Appcompat</code>, you should define a dummy string in your default, unlocalized <code>strings.xml</code> file and place a <code>strings.xml</code> file for each supported locale and define the same string there. For example:</p>
-<pre><code><span class="php"><span class="hljs-meta">&lt;?</span>xml version=<span class="hljs-string">"1.0"</span> encoding=<span class="hljs-string">"utf-8"</span><span class="hljs-meta">?&gt;</span></span>
+<pre><code class="lang-xml"><span class="php"><span class="hljs-meta">&lt;?</span>xml version=<span class="hljs-string">"1.0"</span> encoding=<span class="hljs-string">"utf-8"</span><span class="hljs-meta">?&gt;</span></span>
 <span class="hljs-tag">&lt;<span class="hljs-name">resources</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"dummy"</span>&gt;</span>dummy<span class="hljs-tag">&lt;/<span class="hljs-name">string</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">resources</span>&gt;</span>
-</code></pre><p>This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user. If you don&#39;t do that, Android will always pick the first locale selected by the user.</p>
+</code></pre>
+<p>This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user. If you don&#39;t do that, Android will always pick the first locale selected by the user.</p>
 <h3 id="context-wrapping">Context Wrapping</h3>
 <p>The SDK&#39;s functionality is enabled by wrapping the context, so that all string resource related methods, such a <a href="https://developer.android.com/reference/android/content/res/Resources#getString(int,%20java.lang.Object..."><code>getString()</code></a>), <a href="https://developer.android.com/reference/android/content/res/Resources#getText(int"><code>getText()</code></a>), flow through the SDK.</p>
 <p>To enable context wrapping in your activity, use the following code or have your activity extend a base class:</p>
@@ -119,8 +120,8 @@ advantage of the features that Transifex Native offers, such as OTA translations
 <p>If you want to disable the SDK functionality, don&#39;t initialize it and don&#39;t call any <code>TxNative</code> methods. <code>TxNative.wrap()</code> and <code>TxNative.generalWrap()</code> will be a no-op and the context will not be wrapped. Thus, all <code>getString()</code> etc methods, won&#39;t flow through the SDK.</p>
 <h3 id="fetching-translations">Fetching translations</h3>
 <p>As soon as <code>fetchTranslations()</code> is called, the SDK will attempt to download the 
-translations for all locales - except for the source locale - that are defined in the 
-initialization of <code>TxNative</code>. </p>
+translations for the locales that are defined in the initialization of <code>TxNative</code> and 
+the source locale strings.</p>
 <p>The <code>fetchTranslations()</code> method in the previous example is called as soon as the application launches, but that&#39;s not required. Depending on the application, the developer might choose to call that method whenever it is most appropriate (for example, each time the application is brought to the foreground or when the internet connectivity is established).</p>
 <h3 id="invalidating-cds-cache">Invalidating CDS cache</h3>
 <p>The cache of CDS has a TTL of 30 minutes. If you update some translations on Transifex 
@@ -137,7 +138,7 @@ to the <a href="https://github.com/transifex/transifex-delivery/#invalidate-cach
 <h4 id="alternative-cache-strategy">Alternative cache strategy</h4>
 <p>The SDK allows you to implement your own cache from scratch by implementing the <code>TxCache</code> interface. Alternatively, you may change the standard cache strategy by implementing your own using the SDK&#39;s publicly exposed classes.</p>
 <p>In order to achieve that, you can create a a method that returns a <code>TxCache</code> instance, just like in the <code>TxStandardCache.getCache()</code> case. For example, the standard cache is created as follows:</p>
-<pre><code><span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-type">TxFileOutputCacheDecorator</span>(
+<pre><code class="lang-java"><span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-type">TxFileOutputCacheDecorator</span>(
                 &lt;cached Translations Directory&gt;,
                 <span class="hljs-keyword">new</span> <span class="hljs-type">TXReadonlyCacheDecorator</span>(
                         <span class="hljs-keyword">new</span> <span class="hljs-type">TxProviderBasedCache</span>(
@@ -149,7 +150,8 @@ to the <a href="https://github.com/transifex/transifex-delivery/#invalidate-cach
                         )
                 )
         );
-</code></pre><p>If you want to have your memory cache updated with the new translations when <code>fetchTranslations()</code> is called, you can remove the <code>TXReadonlyCacheDecorator</code>.</p>
+</code></pre>
+<p>If you want to have your memory cache updated with the new translations when <code>fetchTranslations()</code> is called, you can remove the <code>TXReadonlyCacheDecorator</code>.</p>
 <h3 id="sample-app">Sample app</h3>
 <p>You can see the SDK used and configured in more advanced ways in the provided sample app of this repo. You can also check out a simpler app at the <a href="https://github.com/transifex/transifex-native-sandbox">Transifex Native repo</a>.</p>
 <h2 id="transifex-command-line-tool">Transifex Command Line Tool</h2>

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
@@ -46,8 +46,8 @@ public class CDSHandlerAndroid extends CDSHandler {
     /**
      * Creates a CDSHandler instance.
      *
-     * @param localeCodes An array of locale codes that can be downloaded from CDS. It should not
-     *                    include the source language.
+     * @param localeCodes An array of locale codes that can be downloaded from CDS. The source
+     *                    locale can also be included.
      * @param token       The API token to use for connecting to the CDS.
      * @param secret      The API secret to use for connecting to the CDS.
      * @param csdHost     The host of the Content Delivery Service.

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxResources.java
@@ -104,6 +104,16 @@ public class TxResources extends Resources {
         return resourcePackageName.equals("android");
     }
 
+    /**
+     * Returns the {@link Resources} object that is being wrapped.
+     *
+     * @return The {@link Resources} object that is being wrapped.
+     */
+    @NonNull
+    public Resources getWrappedResources() {
+        return mResources;
+    }
+
     @NonNull CharSequence getOriginalText(@StringRes int id) throws NotFoundException {
         return mResources.getText(id);
     }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
@@ -120,7 +120,8 @@ public class Utils {
      * Returns a {@link Resources} object configured for the default (non localized) resources.
      * <p>
      * Getting a string from this object, will return the string found in the default
-     * <code>`strings.xml`</code> file.
+     * <code>`strings.xml`</code> file. Note though that quantity strings will not follow any
+     * locale's plural rules.
      */
     @NonNull
     public static Resources getDefaultLocaleResources(@NonNull Context context) {


### PR DESCRIPTION
Both the SDK and the CLI pull command can now pull source strings.

Updated readme.md and readme.html regarding these changes.

Updated the CLI command description regarding the source strings.

Updated CDSHanlder and CDSHanlderAndroid documentation regarding the source strings.

NativeCore configures CDSHandlerAndroid so that both the translated and the source locales
are downloaded. The translate methods can now serve source strings from the cache and
fall back to the Android provided source strings. The following helper methods have been
created for this purpose: getSourceString(), getSourceQuantityString(). They are used when
the current locale is the source locale and when feeding a source string to the MissingPolicy.

getLocalizedQuantityString() used to follow the plural rules of the current locale. Now it follows
the plural rules of the locale of the provided Resources instance. This way, the method can be
used for the source locale rules or the current locale rules. The method has been made static.

mDefaultResources has been removed as it is not needed.

TxResourcesh has a getWrappedResources() method

A warning has been added to Utils#getDefaultLocaleResources()

Several unit tests have been added to NativeCoreTest to test the usage of source strings
provided by the cache when the source locale is used and when source missing policy is used.
Previous tests have been updated due to the changes in NativeCore methods.