### PR TITLE
Petrakeas/fetch with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ The language codes supported by Transifex can be found [here](https://www.transi
                 null);                     // a MissingPolicy implementation
 
         // Fetch all translations from CDS
-        TxNative.fetchTranslations(null);
+        TxNative.fetchTranslations(null, null);
      }
 ```
 
 In this example, the SDK uses its default cache, `TxStandardCache`, and missing policy, `SourceStringPolicy`. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.
+
+Besides downloading translations for all locales, you can also target specific locales or strings that have specific tags.
 
 Starting from Android N, Android has [multilingual support](https://developer.android.com/guide/topics/resources/multilingual-support.html): users can select more that one locale in Android's settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of `Appcompat`, it suffices to place the supported app languages in your app’s gradle file:
 

--- a/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
+++ b/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
@@ -35,7 +35,7 @@ public class MyApplication extends Application {
         //TxNative.setTestMode(true);
 
         // Fetch all translations from CDS
-        TxNative.fetchTranslations(null);
+        TxNative.fetchTranslations(null, null);
 
         // Start a service just for testing purposes
         Intent serviceIntent = new Intent(this, SimpleIntentService.class);

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/MainClass.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 
@@ -120,7 +121,7 @@ public class MainClass {
         @Option(names = {"-a", "--append-tags"}, arity = "0..",
                 description = "Append custom tags to the pushed source strings.",
                 paramLabel = "<tag>")
-        String[] tags;
+        Set<String> tags;
 
         @Option(names = {"-p", "--purge"},
                 description = "If set, the entire resource content is replaced by the pushed content " +
@@ -180,7 +181,7 @@ public class MainClass {
             }
 
             // Append custom tags
-            if (tags != null && tags.length != 0) {
+            if (tags != null && !tags.isEmpty()) {
                 for (LocaleData.StringInfo stringInfo : sourceStringMap.values()) {
                     stringInfo.appendTags(tags);
                 }
@@ -304,6 +305,12 @@ public class MainClass {
                         "source locale can also be included.", paramLabel = "<locale>")
         String[] translatedLocales;
 
+        @Option(names = {"--with-tags-only"}, arity = "0..",
+                description = "If set, only the strings that have all of the given tags will be " +
+                        "downloaded.",
+                paramLabel = "<tag>")
+        Set<String> tags;
+
         @Override
         public Integer call() throws Exception {
             // Create output directory
@@ -328,7 +335,7 @@ public class MainClass {
             CDSHandler cdsHandler = new CDSHandler(translatedLocales, token, null,
                     mainClass.hostURL);
             TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
-            HashMap<String, File> downloadedFiles = downloader.downloadTranslations(null, outDir, OUT_FILE_NAME);
+            HashMap<String, File> downloadedFiles = downloader.downloadTranslations(null, tags, outDir, OUT_FILE_NAME);
 
             if (downloadedFiles.keySet().containsAll(Arrays.asList(translatedLocales))) {
                 System.out.println("Translations have been pulled successfully from CDS to: " +

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -62,18 +62,18 @@ public class LocaleData {
 
         public Meta meta;
 
-        public void appendTags(@NonNull String[] tags) {
-            if (tags == null || tags.length == 0) {
+        public void appendTags(@NonNull Set<String> tags) {
+            if (tags == null || tags.isEmpty()) {
                 return;
             }
             if (meta == null) {
                 meta = new Meta();
             }
             if (meta.tags == null) {
-                meta.tags = new LinkedHashSet<>(Arrays.asList(tags));
+                meta.tags = new LinkedHashSet<>(tags);
             }
             else {
-                meta.tags.addAll(Arrays.asList(tags));
+                meta.tags.addAll(tags);
             }
         }
 

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationsDownloader.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/TranslationsDownloader.java
@@ -9,6 +9,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,7 +94,10 @@ public class TranslationsDownloader {
      * translation file already exists, it's overwritten.
      *
      * @param localeCode An optional locale to fetch translations from; if  set to <code>null</code>,
-     *                   it will fetch translations for the locale codes provided in the constructor.
+     *                   it will fetch translations for the locale codes configured in the
+     *                   {@link CDSHandler} instance provided in the constructor.
+     * @param tags An optional set of tags. If defined, only strings that have all of the given tags
+     *             will be fetched.
      * @param directory  The directory on which to save the translations. The directory should
      *                   already exist.
      * @param filename   The name of the translation file for a locale.
@@ -102,7 +106,9 @@ public class TranslationsDownloader {
      * translations. If an error occurs, some or all locale codes will be missing from the map.
      */
     @NonNull
-    public HashMap<String, File> downloadTranslations(@Nullable String localeCode, @NonNull File directory,
+    public HashMap<String, File> downloadTranslations(@Nullable String localeCode,
+                                                      @Nullable Set<String> tags,
+                                                      @NonNull File directory,
                                                       @NonNull String filename) {
         if (!directory.isDirectory()) {
             LOGGER.log(Level.SEVERE, "The provided directory does not exist: " + directory.getAbsolutePath());
@@ -114,7 +120,7 @@ public class TranslationsDownloader {
         }
 
         DownloadTranslationsCallback callback = new DownloadTranslationsCallback(directory, filename);
-        mCDSHandler.fetchTranslations(localeCode, callback);
+        mCDSHandler.fetchTranslations(localeCode, tags, callback);
 
         return  callback.filesMap;
     }

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/Utils.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 import androidx.annotation.NonNull;
 
@@ -13,7 +15,8 @@ public class Utils {
     /**
      * Reads an input stream to a string.
      */
-    public @NonNull static String readInputStream(@NonNull InputStream inputStream) throws IOException {
+    public @NonNull
+    static String readInputStream(@NonNull InputStream inputStream) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
         StringBuilder result = new StringBuilder();
         String line;
@@ -58,6 +61,14 @@ public class Utils {
                 success &= deleteDirectory(file);
             }
         }
-        return  success;
+        return success;
+    }
+
+    /**
+     * URL encodes the provided string.
+     */
+    public static String urlEncode(String string) throws UnsupportedEncodingException {
+        // Fixes URLEncoder's escaping of " " with "+" so that it works with URLs
+        return URLEncoder.encode(string, "UTF-8").replace("+", "%20");
     }
 }

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
@@ -79,13 +79,13 @@ public class LocaleDataTest {
     @Test
     public void testStringInfoAppendTags() {
         LocaleData.StringInfo a = new LocaleData.StringInfo("a");
-        a.appendTags(new String[]{"tag1", "tag2"});
+        a.appendTags(new HashSet<>(Arrays.asList("tag1", "tag2")));
 
         assertThat(a.meta).isNotNull();
         assertThat(a.meta.tags).containsExactly("tag1", "tag2");
 
         // Check that new tags are added and that each tag is listed once
-        a.appendTags(new String[]{"tag2", "tag3"});
+        a.appendTags(new HashSet<>(Arrays.asList("tag2", "tag3")));
         assertThat(a.meta.tags).containsExactly("tag1", "tag2", "tag3");
     }
 

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/TranslationsDownloaderTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/TranslationsDownloaderTest.java
@@ -9,7 +9,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -54,7 +57,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, null, tempDir, "strings.txt");
 
         assertThat(translationFiles).isNotNull();
         assertThat(translationFiles).isEmpty();
@@ -71,7 +74,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, null, tempDir, "strings.txt");
 
         RecordedRequest recordedRequest = null;
         try {
@@ -116,7 +119,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, null, tempDir, "strings.txt");
         assertThat(translationFiles).isNotNull();
         assertThat(translationFiles.keySet()).containsExactly("el");
 
@@ -140,7 +143,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations("el", tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations("el", null, tempDir, "strings.txt");
         assertThat(translationFiles).isNotNull();
         assertThat(translationFiles.keySet()).containsExactly("el");
 
@@ -151,6 +154,39 @@ public class TranslationsDownloaderTest {
 
         assertThat(elString).isNotNull();
         assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+    }
+
+    @Test
+    public void testSaveTranslations_specifyTags_normalResponse() {
+        server.setDispatcher(CDSHandlerTest.getElEsWithTagsDispatcher());
+
+        boolean tempDirCreated =  tempDir.mkdirs();
+        assertThat(tempDirCreated).isTrue();
+
+        String[] localeCodes = new String[]{"el", "es"};
+        CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
+        TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
+
+        Set<String> tags = new HashSet<>(Arrays.asList("tag a", "tag b"));
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tags, tempDir, "strings.txt");
+        assertThat(translationFiles).isNotNull();
+        assertThat(translationFiles.keySet()).containsExactly("el", "es");
+
+        String elString = null;
+        try {
+            elString = Utils.readInputStream(new FileInputStream(translationFiles.get("el")));
+        } catch (IOException ignored) {}
+
+        assertThat(elString).isNotNull();
+        assertThat(elString).isEqualTo(CDSHandlerTest.elBody);
+
+        String esString = null;
+        try {
+            esString = Utils.readInputStream(new FileInputStream(translationFiles.get("es")));
+        } catch (IOException ignored) {}
+
+        assertThat(esString).isNotNull();
+        assertThat(esString).isEqualTo(CDSHandlerTest.esBody);
     }
 
     @Test
@@ -173,7 +209,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, null, tempDir, "strings.txt");
         assertThat(translationFiles).isNotNull();
         assertThat(translationFiles.keySet()).containsExactly("el");
 
@@ -206,7 +242,7 @@ public class TranslationsDownloaderTest {
         CDSHandler cdsHandler = new CDSHandler(localeCodes, "token", null, baseUrl);
         TranslationsDownloader downloader = new TranslationsDownloader(cdsHandler);
 
-        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, tempDir, "strings.txt");
+        HashMap<String, File> translationFiles = downloader.downloadTranslations(null, null, tempDir, "strings.txt");
         assertThat(translationFiles).isEmpty();
 
         String esString = null;

--- a/TransifexNativeSDK/doc/readme.html
+++ b/TransifexNativeSDK/doc/readme.html
@@ -44,10 +44,11 @@ advantage of the features that Transifex Native offers, such as OTA translations
                 <span class="hljs-keyword">null</span>);                     <span class="hljs-comment">// a MissingPolicy implementation</span>
 
         <span class="hljs-comment">// Fetch all translations from CDS</span>
-        TxNative.fetchTranslations(<span class="hljs-keyword">null</span>);
+        TxNative.fetchTranslations(<span class="hljs-keyword">null</span>, <span class="hljs-keyword">null</span>);
      }
 </code></pre>
 <p>In this example, the SDK uses its default cache, <code>TxStandardCache</code>, and missing policy, <code>SourceStringPolicy</code>. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.</p>
+<p>Besides downloading translations for all locales, you can also target specific locales or strings that have specific tags.</p>
 <p>Starting from Android N, Android has <a href="https://developer.android.com/guide/topics/resources/multilingual-support.html">multilingual support</a>: users can select more that one locale in Android&#39;s settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of <code>Appcompat</code>, it suffices to place the supported app languages in your app’s gradle file:</p>
 <pre><code class="lang-gradle"><span class="hljs-class">android </span>{
     ...

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.transifex.common.CDSHandler;
 import com.transifex.common.LocaleData;
 
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -64,15 +65,18 @@ public class CDSHandlerAndroid extends CDSHandler {
      *
      * @param localeCode  An optional locale to fetch translations from; if  set to <code>null</code>,
      *                    it will fetch translations for the locale codes provided in the constructor.
+     * @param tags An optional set of tags. If defined, only strings that have all of the given tags
+     *             will be fetched.
      * @param callback A callback function to call when the operation is complete.
      */
     public void fetchTranslationsAsync(@Nullable final String localeCode,
+                                       @Nullable final Set<String> tags,
                                   @NonNull final FetchTranslationsCallback callback) {
         try {
             mExecutor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    LocaleData.TranslationMap result = fetchTranslations(localeCode);
+                    LocaleData.TranslationMap result = fetchTranslations(localeCode, tags);
                     callback.onComplete(result);
                 }
             });

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -15,6 +15,7 @@ import com.transifex.txnative.missingpolicy.MissingPolicy;
 import com.transifex.txnative.missingpolicy.SourceStringPolicy;
 
 import java.util.Locale;
+import java.util.Set;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -115,9 +116,11 @@ public class NativeCore {
      *
      * @param localeCode If set to <code>null</code>, it will fetch translations for all locales
      *                   as defined in the SDK configuration.
+     * @param tags An optional set of tags. If defined, only strings that have all of the given tags
+     *             will be fetched.
      */
-    void fetchTranslations(@Nullable String localeCode) {
-        mCDSHandler.fetchTranslationsAsync(localeCode, new CDSHandlerAndroid.FetchTranslationsCallback() {
+    void fetchTranslations(@Nullable String localeCode, @Nullable Set<String> tags) {
+        mCDSHandler.fetchTranslationsAsync(localeCode, tags, new CDSHandlerAndroid.FetchTranslationsCallback() {
             @Override
             public void onComplete(final @Nullable LocaleData.TranslationMap translationMap) {
                 if (translationMap != null && !translationMap.isEmpty()) {

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -10,6 +10,9 @@ import com.transifex.txnative.wrappers.TxContextWrapper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.transifex.txnative.cache.TxCache;
+
+import java.util.Set;
+
 import io.github.inflationx.viewpump.ViewPump;
 import io.github.inflationx.viewpump.ViewPumpContextWrapper;
 
@@ -120,13 +123,28 @@ public class TxNative {
      * @param localeCode An optional locale to fetch translations for; if  set to <code>null</code>,
      *                   it will fetch translations for all locales as defined in the SDK
      *                   configuration.
+     * @param tags An optional set of tags. If defined, only strings that have all of the given tags
+     *             will be fetched.
+     */
+    public static void fetchTranslations(@Nullable String localeCode, @Nullable Set<String> tags) {
+        if (sNativeCore == null) {
+            throw new RuntimeException("TxNative has not been initialized");
+        }
+
+        sNativeCore.fetchTranslations(localeCode, tags);
+    }
+
+    /**
+     * Fetches the translations from CDS and updates the cache.
+     * 
+     * @see #fetchTranslations(String, Set) 
      */
     public static void fetchTranslations(@Nullable String localeCode) {
         if (sNativeCore == null) {
             throw new RuntimeException("TxNative has not been initialized");
         }
 
-        sNativeCore.fetchTranslations(localeCode);
+        sNativeCore.fetchTranslations(localeCode, null);
     }
 
     /**


### PR DESCRIPTION
TxNative#fetchTranslations() and the CLI allow specifying a set
of tags so that only strings that have all these tags are fetched.

TxNative kept the original fetchTranslations() method without the "tags" argument for
backwards compatibility.  A new fetchTranslations() method with the tags argument has been added.

All related CDSHandler methods accept a "tags" argument that is nullable.
If not null, getLocationForLocale() converts the set of tags to URL query parameters
and URL escapes them.

TranslationsDownloader#downloadTransations() can now accept a "tags" argument.

Utils#urlEncode method was introduced that use URLEncoder and further replaces the
escaped space with "%20" so that it's ok to use with URLS and not HTML forms, which is
what URLEncoder was designed for.

LocaleData#appendTags() accepts a set instead of a string array.

Readme now mentions the ability to filter the fetched strings by tag.

Unit tests have been added.