### PR TITLE
Update CDSHandler logic to v2

### DIFF
--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/MainClassTest.java
@@ -95,18 +95,34 @@ public class MainClassTest {
     }
 
     public static Dispatcher getPostDispatcher() {
+
         Dispatcher dispatcher = new Dispatcher() {
+
+            final String jobId = "abcd";
+            final String jobLink = "/jobs/content/" + jobId;
+            final Gson gson = new Gson();
 
             @NonNull
             @Override
             public MockResponse dispatch (RecordedRequest request) throws InterruptedException {
 
-                String dummyCDSResponse = "{\"created\":0,\"updated\":0,\"skipped\":0,\"deleted\":0,\"failed\":0,\"errors\":[]}";
-
                 switch (request.getPath()) {
                     case "/content":
-                        return new MockResponse().setResponseCode(200).setBody(dummyCDSResponse);
+                        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
+                        responseData.data = new LocaleData.TxPostResponseData.Data();
+                        responseData.data.id = jobId;
+                        responseData.data.links = new LocaleData.TxPostResponseData.Data.Links();
+                        responseData.data.links.job = jobLink;
+                        return new MockResponse().setResponseCode(202).setBody(gson.toJson(responseData));
+                    case jobLink:
+                        LocaleData.TxJobStatus jobStatus = new LocaleData.TxJobStatus();
+                        jobStatus.data = new LocaleData.TxJobStatus.Data();
+                        jobStatus.data.status = "completed";
+                        jobStatus.data.details = new LocaleData.TxJobStatus.Data.Details();
+                        jobStatus.data.details.created = 2;
+                        return new MockResponse().setResponseCode(200).setBody(gson.toJson(jobStatus));
                 }
+
                 return new MockResponse().setResponseCode(404);
             }
         };

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -185,33 +185,68 @@ public class LocaleData {
      *     https://github.com/transifex/transifex-delivery/#push-content</a>
      */
     public static class TxPostResponseData {
-        public int created;
-        public int updated;
-        public int skipped;
-        public int deleted;
-        public int failed;
-        public Error[] errors;
 
-        public boolean isSuccessful() {
-            return errors == null || errors.length == 0;
-        }
-
-        public static class Error {
-            public int status;
-            public String code;
-            public String title;
-            public String detail;
-
-            @Override
-            public String toString() {
-                return "Error{" +
-                        "status=" + status +
-                        ", code='" + code + '\'' +
-                        ", title='" + title + '\'' +
-                        ", detail='" + detail + '\'' +
-                        '}';
+        public static class Data {
+            public static class Links {
+                public String job;
             }
+
+            public String id;
+            public Links links;
         }
+
+        public Data data;
+    }
+
+    /**
+     * The data structure that CDS responds with when getting the job status after pushing the
+     * source strings.
+     *
+     * @see <a href="https://github.com/transifex/transifex-delivery/#job-status">
+     *     https://github.com/transifex/transifex-delivery/#job-status</a>
+     */
+    public static class TxJobStatus {
+         public static class Data {
+
+             public static class Error {
+                 public int status;
+                 public String code;
+                 public String title;
+                 public String detail;
+
+                 @Override
+                 public String toString() {
+                     return "Error{" +
+                             "status=" + status +
+                             ", code='" + code + '\'' +
+                             ", title='" + title + '\'' +
+                             ", detail='" + detail + '\'' +
+                             '}';
+                 }
+             }
+
+             public static class Details {
+                 public int created;
+                 public int updated;
+                 public int skipped;
+                 public int deleted;
+                 public int failed;
+             }
+
+             public Details details;
+             public Error[] errors;
+             public String status;
+         }
+
+         public Data data;
+
+         public boolean isCompleted() {
+            return data.status.equals("completed");
+         }
+
+         public boolean hasErrors() {
+            return data.errors == null || data.errors.length != 0;
+         }
     }
 
     //endregion

--- a/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
+++ b/TransifexNativeSDK/common/src/test/java/com/transifex/common/LocaleDataTest.java
@@ -187,26 +187,39 @@ public class LocaleDataTest {
     }
 
     @Test
-    public void testTxPostResponseDataIsSuccessful_noErrors_successful() {
-        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
+    public void testTxJobStatusIsCompleted_completed_returnTrue() {
+        LocaleData.TxJobStatus responseData = new LocaleData.TxJobStatus();
+        responseData.data = new LocaleData.TxJobStatus.Data();
+        responseData.data.status = "completed";
 
-        assertThat(responseData.isSuccessful()).isTrue();
+        assertThat(responseData.isCompleted()).isTrue();
     }
 
     @Test
-    public void testTxPostResponseDataIsSuccessful_emptyErrorArray_successful() {
-        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
-        responseData.errors = new LocaleData.TxPostResponseData.Error[0];
+    public void testTxJobStatusIsCompleted_failed_returnFalse() {
+        LocaleData.TxJobStatus jobStatus = new LocaleData.TxJobStatus();
+        jobStatus.data = new LocaleData.TxJobStatus.Data();
+        jobStatus.data.status = "failed";
 
-        assertThat(responseData.isSuccessful()).isTrue();
+        assertThat(jobStatus.isCompleted()).isFalse();
     }
 
     @Test
-    public void testTxPostResponseDataIsSuccessful_errors_notSuccessful() {
-        LocaleData.TxPostResponseData responseData = new LocaleData.TxPostResponseData();
-        responseData.errors = new LocaleData.TxPostResponseData.Error[]{new LocaleData.TxPostResponseData.Error()};
+    public void testTxJobStatusHasErrors_emptyErrorArray_returnFalse() {
+        LocaleData.TxJobStatus jobStatus = new LocaleData.TxJobStatus();
+        jobStatus.data = new LocaleData.TxJobStatus.Data();
+        jobStatus.data.errors = new LocaleData.TxJobStatus.Data.Error[0];
 
-        assertThat(responseData.isSuccessful()).isFalse();
+        assertThat(jobStatus.hasErrors()).isFalse();
+    }
+
+    @Test
+    public void testTxJobStatusHasErrors_hasError_returnTrue() {
+        LocaleData.TxJobStatus jobStatus = new LocaleData.TxJobStatus();
+        jobStatus.data = new LocaleData.TxJobStatus.Data();
+        jobStatus.data.errors = new LocaleData.TxJobStatus.Data.Error[]{new LocaleData.TxJobStatus.Data.Error()};
+
+        assertThat(jobStatus.hasErrors()).isTrue();
     }
 
 }


### PR DESCRIPTION
Updates CDSHandler logic so that it can work with the version 2
of the CDS documentation. Updates the push logic with the new job
oriented approach.

Updates the response data structures that the new CDS version produces (LocadeData).

Refactor CLI's MainClass to account for the updates in CDSHandler and LcoaleData.

Updates unit tests for the class and method refactoring.

Adds unit tests for the new job oriented approach on push.