### PR TITLE
Ignore String references when parsing Android XML resources

### DIFF
--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
@@ -101,6 +101,10 @@ class StringXMLConverter {
             if (child.getName().equals("string")) {
                 String key = child.getAttribute("name").getValue();
                 String string = getXMLText(child);
+                // Ignore resource references
+                if (string.startsWith("@")) {
+                    continue;
+                }
                 stringMap.put(key, new LocaleData.StringInfo(string));
             }
             else if (child.getName().equals("plurals")) {
@@ -109,11 +113,19 @@ class StringXMLConverter {
                 if (pluralItems.isEmpty()) {
                     continue;
                 }
+                boolean hasResourceReference = false;
                 Plurals.Builder sb = new Plurals.Builder();
                 for (Element item : pluralItems) {
                     String quantity = item.getAttribute("quantity").getValue();
                     String itemString = getXMLText(item);
+                    if (itemString.startsWith("@")) {
+                        hasResourceReference = true;
+                        break;
+                    }
                     sb.setPlural(quantity, itemString);
+                }
+                if (hasResourceReference) {
+                    continue;
                 }
                 Plurals plurals;
                 try {

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
@@ -25,6 +25,8 @@ public class StringXMLConverterTest {
                     "    <string name=\"key1\">Some text</string>\n" +
                     "\n" +
                     "    <string name=\"key2\">Some text 2</string>\n" +
+                    "\n" +
+                    "    <string name=\"key3\">@string/key2</string>\n" +
                     "</resources>";
     private static final String stringsXMLTranslatable =
             "<resources>\n" +


### PR DESCRIPTION
StringXMLConverter ignores strings that reference other strings.
For example, "<string name="foo">@string/bar</string>"
will be ignored.

The XML string used in the unit test, now contains a string with a
string reference.