### PR TITLE
Update to Gradle 7.2 and JDK 12

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,10 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 12
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: '12'
+        distribution: 'adopt'
     - name: Cache Gradle packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 12
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: '12'
         distribution: 'adopt'
     - name: Cache Gradle packages
       uses: actions/cache@v2

--- a/TransifexNativeSDK/build.gradle
+++ b/TransifexNativeSDK/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.versions = [
-            'kotlin' : '1.4.32',
+            'kotlin' : '1.5.20',
             'androidXAnnotation' : '1.2.0'
     ]
     ext {
@@ -13,10 +13,10 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -31,7 +31,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -88,6 +88,8 @@ gradle.projectsEvaluated {
         options {
             addStringOption 'docencoding', 'utf-8'
             addStringOption 'charset', 'utf-8'
+            addStringOption 'source', '8'
+            addStringOption('Xdoclint:none', 'quiet')
             addStringOption 'overview', 'doc/readme.html'
             links 'https://docs.oracle.com/javase/7/docs/api/'
             links 'https://d.android.com/reference'

--- a/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
+++ b/TransifexNativeSDK/common/src/main/java/com/transifex/common/LocaleData.java
@@ -360,7 +360,7 @@ public class LocaleData {
         private final HashMap<String, LocaleStrings> mHashMap;
 
         /**
-         * Constructs an empty <tt>TranslationMap</tt> with the specified initial capacity.
+         * Constructs an empty <code>TranslationMap</code> with the specified initial capacity.
          *
          * @param initialCapacity The initial capacity. Set to the number of expected locales.
          */

--- a/TransifexNativeSDK/gradle/wrapper/gradle-wrapper.properties
+++ b/TransifexNativeSDK/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 27 14:14:42 EET 2020
+#Mon Sep 20 14:45:43 EEST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/TransifexNativeSDK/publish-helper.gradle
+++ b/TransifexNativeSDK/publish-helper.gradle
@@ -21,6 +21,8 @@ task androidJavadoc(type: Javadoc) {
     options {
         addStringOption 'docencoding', 'utf-8'
         addStringOption 'charset', 'utf-8'
+        addStringOption 'source', '8'
+        addStringOption('Xdoclint:none', 'quiet')
         links 'https://docs.oracle.com/javase/7/docs/api/'
         links 'https://d.android.com/reference'
         links 'https://developer.android.com/reference/androidx/'

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/CDSHandlerAndroid.java
@@ -27,7 +27,7 @@ public class CDSHandlerAndroid extends CDSHandler {
     private final Executor mExecutor;
 
     /**
-     * A callback that provides the results of {@link #fetchTranslationsAsync(String, FetchTranslationsCallback)}
+     * A callback that provides the results of {@link #fetchTranslationsAsync(String, Set, FetchTranslationsCallback)}
      * when the operation is complete.
      */
     interface FetchTranslationsCallback {


### PR DESCRIPTION
Updated Gradle to 7.2 and Android Gradle plugin to 7.0.2

This Gradle version requires JDK 11. JDK 11 has a bug when
generating the Javadoc, which results in broken search functionality.
This is why we will use JDK 12.

Updated Github workflows to use JDK 12.

Replaced jcenter with mavenCentral.

Added some arguments for javadoc generation so that it
executes correctly with the latest JDK.

Corrected two errors in the documentation.