### PR TITLE
Support material components

### DIFF
--- a/TransifexNativeSDK/app/build.gradle
+++ b/TransifexNativeSDK/app/build.gradle
@@ -34,6 +34,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
+++ b/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
@@ -41,7 +41,7 @@ public class MyApplication extends Application {
 //        TxNative.setTestMode(true);
 
         // Required to render the HTML styling of R.string.styled_text_not_escaped
-//        TxNative.setSupportSpannable(true);
+        TxNative.setSupportSpannable(true);
 
         // Fetch all translations from CDS
         TxNative.fetchTranslations(null, null);

--- a/TransifexNativeSDK/app/src/main/res/layout/activity_main.xml
+++ b/TransifexNativeSDK/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,6 @@
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingTop="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -132,7 +131,21 @@
                     android:inputType="text"
                     android:textAlignment="center" />
 
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/material_test"
+                    android:layout_width="290dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:hint="@string/hint_problem">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"/>
+
+                </com.google.android.material.textfield.TextInputLayout>
+
             </LinearLayout>
+
         </ScrollView>
 
 

--- a/TransifexNativeSDK/app/src/main/res/values-el/strings.xml
+++ b/TransifexNativeSDK/app/src/main/res/values-el/strings.xml
@@ -26,6 +26,10 @@
 
     <string name="styled_text">A &lt;font color="#FF7700">localization&lt;/font> platform &lt;u>that&lt;/u> moves as &lt;b>fast&lt;/b> as &lt;big>you&lt;/big> do\n https://www.transifex.com/ ελ</string>
 
+    <string name="styled_text_not_escaped">This is <font face="monospace" color="#0000FF">blue</font> ελ</string>
+
+    <string name="hint_problem">Describe the problem in detail <font color='#FF0000'>*</font> ελ</string>
+
     <string name="dark_theme">Dark theme ελ</string>
 
     <string name="light_theme">Light theme ελ</string>

--- a/TransifexNativeSDK/app/src/main/res/values/strings.xml
+++ b/TransifexNativeSDK/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
 
     <string name="styled_text_not_escaped">This is <font face="monospace" color="#0000FF">blue</font></string>
 
+    <string name="hint_problem">Describe the problem in detail <font color='#FF0000'>*</font></string>
+
     <string name="dark_theme">Dark theme</string>
 
     <string name="light_theme">Light theme</string>

--- a/TransifexNativeSDK/app/src/main/res/values/styles.xml
+++ b/TransifexNativeSDK/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppBaseTheme" parent="Theme.AppCompat.DayNight.DarkActionBar"/>
+    <style name="AppBaseTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar"/>
 
     <style name="AppTheme" parent="AppLightTheme"/>
 

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     compileOnly 'androidx.appcompat:appcompat:1.5.1'
+    compileOnly 'com.google.android.material:material:1.6.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'io.github.inflationx:viewpump:2.0.3'
     api project(':common')

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxInterceptor.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxInterceptor.java
@@ -7,7 +7,9 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toolbar;
 
+import com.google.android.material.textfield.TextInputLayout;
 import com.transifex.txnative.transformers.SupportToolbarTransformer;
+import com.transifex.txnative.transformers.TextInputLayoutTransformer;
 import com.transifex.txnative.transformers.TextViewTransformer;
 import com.transifex.txnative.transformers.ToolbarTransformer;
 import com.transifex.txnative.transformers.ViewTransformer;
@@ -33,6 +35,7 @@ class TxInterceptor implements Interceptor {
     private final TextViewTransformer mTextViewTransformer;
     private ToolbarTransformer mToolbarTransformer;
     private final SupportToolbarTransformer mSupportToolbarTransformer;
+    private final TextInputLayoutTransformer mTextInputLayoutTransformer;
 
     public TxInterceptor() {
         mViewTransformer = new ViewTransformer();
@@ -41,6 +44,7 @@ class TxInterceptor implements Interceptor {
             mToolbarTransformer = new ToolbarTransformer();
         }
         mSupportToolbarTransformer = new SupportToolbarTransformer();
+        mTextInputLayoutTransformer = new TextInputLayoutTransformer();
     }
 
     @NonNull
@@ -61,6 +65,9 @@ class TxInterceptor implements Interceptor {
             }
             else if (Utils.isAppcompatPresent() && view instanceof androidx.appcompat.widget.Toolbar) {
                 mSupportToolbarTransformer.transform(context, view, attrs);
+            }
+            else if (Utils.isMaterialComponentsPresent() && view instanceof TextInputLayout) {
+                mTextInputLayoutTransformer.transform(context, view, attrs);
             }
             else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && view instanceof Toolbar) {
                 mToolbarTransformer.transform(context, view, attrs);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/Utils.java
@@ -21,9 +21,11 @@ public class Utils {
     private static final String TAG = Utils.class.getSimpleName();
 
     private static final boolean sIsAppcompatPresent;
+    private static final boolean sIsMaterialComponenetsPresent;
 
     static {
         sIsAppcompatPresent = isClassPresent("androidx.appcompat.widget.Toolbar");
+        sIsMaterialComponenetsPresent = isClassPresent("com.google.android.material.textfield.TextInputLayout");
     }
 
     /**
@@ -185,5 +187,13 @@ public class Utils {
      */
     public static boolean isAppcompatPresent() {
         return sIsAppcompatPresent;
+    }
+
+    /**
+     * Checks if <a href="https://material.io/develop/android/docs/getting-started"><code>Material Components</code></a>
+     * classes are available at runtime.
+     */
+    public static boolean isMaterialComponentsPresent() {
+        return sIsMaterialComponenetsPresent;
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/transformers/TextInputLayoutTransformer.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/transformers/TextInputLayoutTransformer.java
@@ -1,0 +1,25 @@
+package com.transifex.txnative.transformers;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.google.android.material.textfield.TextInputLayout;
+import com.transifex.txnative.Utils;
+
+import androidx.annotation.NonNull;
+
+public class TextInputLayoutTransformer extends ViewTransformer{
+
+    @Override
+    public void transform(@NonNull Context context, @NonNull View view, @NonNull AttributeSet attrs) {
+        super.transform(context, view, attrs);
+
+        TextInputLayout textInputLayout = (TextInputLayout) view;
+
+        int hintResourceId = Utils.getStringResourceId(context, attrs, android.R.attr.hint);
+        if (hintResourceId != 0) {
+            textInputLayout.setHint(hintResourceId);
+        }
+    }
+}


### PR DESCRIPTION
Even though the SDK did not support material components, most components worked correctly since they extended vanilla Android View classes and they were handled by our TxInterceptor.

`TextInputLayout` though did not work correctly. This is why we now explicitly check for this class in our `TxInterceptorand` and handle it in the `TextInputLayoutTransformer.`

The following components were also tested and found to work correctly: `MaterialButton`, `MaterialCardView`.

The SDK uses `material:1.6.1` as a compileOnly dependency, similarly to `appcompat`.

The demo app now uses e  `material:1.6.1`. The theme extends a MaterialComponents theme instead of an AppCompat theme. A TextInputLayout element has been added to the main activity's layout. The SDK's Spannable support is now enabled.