### PR TITLE
Improve spannable support performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The cache can be prepopulated by the developer, using the command-line tool's [p
 
 ### Standard Cache
 
-The default cache strategy used by the SDK, if no other cache is provided by the developer, is returned by [TxStandardCache.getCache()](https://transifex.github.io/transifex-java/com/transifex/txnative/cache/TxStandardCache.html#getCache-android.content.Context-java.lang.Integer-java.io.File-). The standard cache operates by making use of the publicly exposed classes and interfaces from the [com.transifex.txnative.cache](https://transifex.github.io/transifex-java/com/transifex/txnative/cache/package-summary) package of the SDK, so it's easy to construct another cache strategy if that's desired.
+The default cache strategy used by the SDK, if no other cache is provided by the developer, is returned by [TxStandardCache.getCache()](https://transifex.github.io/transifex-java/com/transifex/txnative/cache/TxStandardCache.html#getCache(android.content.Context,java.lang.Integer,java.io.File)). The standard cache operates by making use of the publicly exposed classes and interfaces from the [com.transifex.txnative.cache](https://transifex.github.io/transifex-java/com/transifex/txnative/cache/package-summary) package of the SDK, so it's easy to construct another cache strategy if that's desired.
 
 The standard cache is initialized with a memory cache that manages all cached entries in memory. When the memory cache gets initialized, it tries to look up if there are any already stored translations in the file system:
 
@@ -175,7 +175,7 @@ If you want to have your memory cache updated with the new translations when `fe
 
 ## Fetching translations
 
-As soon as [fetchTranslations()](https://transifex.github.io/transifex-java/com/transifex/txnative/TxNative.html#fetchTranslations-java.lang.String-java.util.Set-) is called, the SDK will attempt to download both the source locale strings
+As soon as [fetchTranslations()](https://transifex.github.io/transifex-java/com/transifex/txnative/TxNative.html#fetchTranslations(java.lang.String,java.util.Set)) is called, the SDK will attempt to download both the source locale strings
 and the translations for the supported locales. If successful, it will update the cache. 
 
 The `fetchTranslations()` method in the SDK configuration example is called as soon as the application launches, but that's not required. Depending on the application, the developer might choose to call that method whenever it is most appropriate (for example, each time the application is brought to the foreground or when the internet connectivity is established).
@@ -261,29 +261,30 @@ There are cases where you don't want TxNative to interfere with string loading. 
 ```
 ### String styling
 
-As explained in Android's [documentation](https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML), strings can have styling applied to them if they contain HTML markup.
+As explained in Android's [documentation](https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML), strings can have styling applied to them if they contain HTML markup. There are two ways to accomplish that.
 
-You can write a string with HTML tags, where the opening brackets have been escaped (using `&lt;` instead of `<`): 
-
-```
-<string name="styled_text">A &lt;font color="#FF7700">localization&lt;/font> platform</string>
-```
-
-Then you can use [`fromHTML()`](https://developer.android.com/reference/androidx/core/text/HtmlCompat#fromHtml(java.lang.String,int,android.text.Html.ImageGetter,android.text.Html.TagHandler)) to get styled text:
-
-```java
-String string = getResources().getString(R.string.styled_text);
-Spanned styledString = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_COMPACT);
-someView.setText(styledString);
-```
-
-If your string is referenced in an XML layout resource and you don't want set it programatically, write the string with normal opening brackets:
+Write a string  with HTML markup. For example:
 
 ```xml
 <string name="styled_text">A <font color="#FF7700">localization</font> platform</string>
 ```
 
-and enable [`TxNative.setSupportSpannable(true)`](https://transifex.github.io/transifex-java/com/transifex/txnative/TxNative.html#setSupportSpannable-boolean-). If the SDK detects tags in your string, it will use `fromHTML()` to render them correctly. Note that new lines will be converted to spaces and sequences of whitespace characters will be collapsed into a single space.
+The SDK will parse the tags into spans so that styling is applied. You can reference such a string in a layout XML file or use `getText()` (not `getString()`) and set it programmatically to the desired view. To disable this behavior and treat tags as plain text, you can disable span support by calling [`TxNative.setSupportSpannable(false)`](https://transifex.github.io/transifex-java/com/transifex/txnative/TxNative.html#setSupportSpannable(boolean)). 
+Note that when span support is enabled, the SDK uses `fromHTML()` internally when tags are detected. This has the side-effect of new lines being converted to spaces and sequences of whitespace characters being collapsed into a single space.
+
+Alternatively, you can write a string with the opening brackets escaped (using `&lt;` instead of `<`): 
+
+```xml
+<string name="styled_text">A &lt;font color="#FF7700">localization&lt;/font> platform</string>
+```
+
+Then, you can use [`fromHTML()`](https://developer.android.com/reference/androidx/core/text/HtmlCompat#fromHtml(java.lang.String,int,android.text.Html.ImageGetter,android.text.Html.TagHandler)) to get styled text as shown below:
+
+```java
+String string = getResources().getString(R.string.styled_text);
+Spanned styledTest = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_COMPACT);
+someView.setText(styledText);
+```
 
 ### Stylable attributes
 

--- a/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MainActivity.java
+++ b/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MainActivity.java
@@ -71,12 +71,12 @@ public class MainActivity extends TxBaseAppCompatActivity {
             mFormatLabel.setText(formattedString);
         }
 
-        // Styled string
+        // Styled text
         mStyledLabel = findViewById(R.id.styled_label);
         {
             String string = getResources().getString(R.string.styled_text);
-            Spanned styledString = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_COMPACT);
-            mStyledLabel.setText(styledString);
+            Spanned styledText = HtmlCompat.fromHtml(string, HtmlCompat.FROM_HTML_MODE_COMPACT);
+            mStyledLabel.setText(styledText);
         }
 
         // Themed attribute referencing string resource

--- a/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
+++ b/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/MyApplication.java
@@ -40,8 +40,9 @@ public class MyApplication extends Application {
         // Uncomment to use strings as served by Android prefixed with "test: "
 //        TxNative.setTestMode(true);
 
-        // Required to render the HTML styling of R.string.styled_text_not_escaped
-        TxNative.setSupportSpannable(true);
+        // Uncomment, to disable styling of strings with HTML markup such as
+        // R.string.styled_text_not_escaped
+//        TxNative.setSupportSpannable(false);
 
         // Fetch all translations from CDS
         TxNative.fetchTranslations(null, null);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -82,24 +82,27 @@ public class TxNative {
 
     /**
      * If enabled, the <code>getText()</code> method can return a {@link android.text.SpannedString SpannedString}
-     * if tags exist in the source string. If disabled, a plain String is always returned. It's
-     * disabled by default.
+     * where all tags are parsed into spans. If disabled, a  {@link String} is returned at all times
+     * and all tags are kept as plain text. It's enabled by default.
      * <p>
-     * Enable it, if your strings contain HTML tags using {@code "<"} and  {@code ">"} characters.
-     * Leave it disabled if your strings are HTML-escaped such as the following:
+     * Leave it enabled, if you have strings that contain HTML tags using {@code "<"} and  {@code ">"}
+     * characters and you want HTML styling to be applied when the strings are referenced in your
+     * layout.
+     * <p>
+     * Disable it if your strings are HTML-escaped such as the following:
      * <pre>{@code
      * <resources>
      *   <string name="welcome_messages">Hello, %1$s! You have &lt;b>%2$d new messages&lt;/b>.</string>
      * </resources>
      * }
      * </pre>
-     *
-     * <p>
-     * If enabled, {@link androidx.core.text.HtmlCompat#fromHtml(String, int)} is
-     * used internally which is more CPU demanding than if left disabled.
+     * In this case, you can use {@link androidx.core.text.HtmlCompat#fromHtml(String, int)}
+     * on the result of <code>getText()</code> or <code>getString()</code> to get a SpannedString,
+     * which you can set to a view programmatically.
      *
      * @see <a href="https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML">
      *     https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML</a>
+     * @see NativeCore#getSpannedString(String)
      */
     public static void setSupportSpannable(boolean enabled ){
         if (sNativeCore == null) {

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/NativeCoreTest.java
@@ -391,6 +391,7 @@ public class NativeCoreTest {
                 null);
         TxMemoryCache dummyCache = getEmptyMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
+        nativeCore.setSupportSpannable(false);
 
         CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS);
 
@@ -425,6 +426,7 @@ public class NativeCoreTest {
                 null);
         TxMemoryCache dummyCache = getEmptyMemoryCache();
         NativeCore nativeCore = new NativeCore(mockContext, localeState, "token", null, dummyCache, null);
+        nativeCore.setSupportSpannable(false);
 
         CharSequence string = nativeCore.getSpannedString(STRING_WITH_TAGS_HTML_ESCAPED);
 
@@ -452,6 +454,10 @@ public class NativeCoreTest {
     public void testGetSpannedString_spanSupportDisabledWithSimpleStringWithHTMLEntities_returnStringWithUnescapedHTMLEntities() {
         // We expect to get a String object, since no tags exist in the  parsed string. New lines and
         // multiple spaces should be preserved. "&amp;" should be converted to "&"
+
+        // This test is the same as
+        // testGetSpannedString_spanSupportEnabledWithSimpleStringWithHTMLEntities_returnStringWithUnescapedHTMLEntities
+        // The result should be the same, regardless of spannable support.
 
         LocaleState localeState = new LocaleState(mockContext,
                 "en",


### PR DESCRIPTION
Spanable support is now enabled by default. The documentation and readme have been updated accordingly. An affected unit test has been updated.

When NativeCore#setSupportSpannable(true) was called, strings were processed by fromHTML() even when they contained no tags. Since fromHTML() has a performance cost, we had a perfomrance penalty even when we didn't need it.

With this update, we apply fromHTML() only in strings that contain a "<" character and hence probably contain tags. This way, the performance penalty occurs only when needed.