### PR TITLE
Pass wrapped resources in AndroidMissingPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ The language codes supported by Transifex can be found [here](https://explore.tr
      }
 ```
 
-In this example, the SDK uses its default cache, `TxStandardCache`, and default missing policy, `SourceStringPolicy`. However, you can choose between different cache and missing policy implementations or even provide your own. You can read more on that later.
+In this example, the SDK uses its default cache, `TxStandardCache`, and default missing policy, `SourceStringPolicy`. However, you can choose between different cache and missing policy implementations or even provide your own. For example, if you want to fallback to translations provided via `strings.xml` files, use the [`AndroidMissingPolicy`](https://transifex.github.io/transifex-java/com/transifex/txnative/missingpolicy/AndroidMissingPolicy.html). You can read more about cache implementations later on.
 
 In this example, we fetch the translations for all locales. If you want, you can target specific locales or strings that have specific tags.
 
-Starting from Android N, Android has [multilingual support](https://developer.android.com/guide/topics/resources/multilingual-support.html): users can select more that one locale in Android's settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of `Appcompat`, it suffices to place the supported app languages in your app’s gradle file:
+## App configuration
+
+Starting from Android N, Android has [multilingual support](https://developer.android.com/guide/topics/resources/multilingual-support.html): users can select more that one locale in Android's settings and the OS will try to pick the topmost locale that is supported by the app. If your app makes use of `Appcompat`, place the supported app languages in your app’s gradle file:
 
 ```gradle
 android {
@@ -84,7 +86,9 @@ android {
     }
 ```
 
-If your app doesn't use `Appcompat`, you should define a dummy string in your default, unlocalized `strings.xml` file and place a `strings.xml` file for each supported locale and define the same string there. For example:
+This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user.
+
+For some languages such as Kinyarwanda, you will need to do some more work. You should define a dummy string in your default, unlocalized `strings.xml` file and place a `strings.xml` file for that locale and define the same string there. For example:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -93,7 +97,9 @@ If your app doesn't use `Appcompat`, you should define a dummy string in your de
 </resources>
 ```
 
-This will let Android know which locales your app supports and help it choose the correct one in case of a multilingual user. If you don't do that, Android will always pick the first locale selected by the user.
+If you don't do that, Android will never choose that language.
+
+If you don't use `Appcompat` you will have to place a `strings.xml` for all supported locales.
 
 ## Context Wrapping
 
@@ -270,7 +276,7 @@ Write a string  with HTML markup. For example:
 ```
 
 The SDK will parse the tags into spans so that styling is applied. You can reference such a string in a layout XML file or use `getText()` (not `getString()`) and set it programmatically to the desired view. To disable this behavior and treat tags as plain text, you can disable span support by calling [`TxNative.setSupportSpannable(false)`](https://transifex.github.io/transifex-java/com/transifex/txnative/TxNative.html#setSupportSpannable(boolean)). 
-Note that when span support is enabled, the SDK uses `fromHTML()` internally when tags are detected. This has the side-effect of new lines being converted to spaces and sequences of whitespace characters being collapsed into a single space.
+Note that when span support is enabled and tags are detected in a string, the SDK uses `fromHTML()`. This has the side-effect of new lines being converted to spaces and sequences of whitespace characters being collapsed into a single space.
 
 Alternatively, you can write a string with the opening brackets escaped (using `&lt;` instead of `<`): 
 

--- a/TransifexNativeSDK/app/build.gradle
+++ b/TransifexNativeSDK/app/build.gradle
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
     compileOnly 'androidx.appcompat:appcompat:1.5.1'
-    compileOnly 'com.google.android.material:material:1.6.1'
+    compileOnly 'com.google.android.material:material:1.7.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation 'io.github.inflationx:viewpump:2.0.3'
     api project(':common')

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -233,8 +233,8 @@ public class NativeCore {
         // 4. the key was not found in the Cache for the resolved locale
         if (TextUtils.isEmpty(translatedString)) {
             CharSequence sourceString = getSourceString(txResources, id);
-            return mMissingPolicy.get(sourceString, id, txResources.getResourceEntryName(id),
-                    mLocaleState.getResolvedLocale());
+            return mMissingPolicy.get(txResources.getWrappedResources(), sourceString, id,
+                    txResources.getResourceEntryName(id),mLocaleState.getResolvedLocale());
         }
 
         return getSpannedString(translatedString);
@@ -288,8 +288,9 @@ public class NativeCore {
         // No ICU string found in cache or no quantity string was rendered
         if (TextUtils.isEmpty(quantityString)) {
             CharSequence sourceString = getSourceQuantityString(txResources, id, quantity);
-            return mMissingPolicy.getQuantityString(sourceString, id, quantity,
-                    txResources.getResourceEntryName(id), mLocaleState.getResolvedLocale());
+            return mMissingPolicy.getQuantityString(txResources.getWrappedResources(),
+                    sourceString, id, quantity, txResources.getResourceEntryName(id),
+                    mLocaleState.getResolvedLocale());
         }
 
         return getSpannedString(quantityString);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicy.java
@@ -1,27 +1,36 @@
 package com.transifex.txnative.missingpolicy;
 
 import android.content.Context;
+import android.content.res.Resources;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
 
 /**
- * Returns the string using Android's localization system.
+ * Returns a translated string using Android's localization system.
+ * <p>
+ * You can use this policy to fall back to translations provided via <code>strings.xml</code>
+ * when a translation string can't be provided by TxNative's cache.
  */
 public class AndroidMissingPolicy implements MissingPolicy{
 
-    Context context;
+
+    public AndroidMissingPolicy(){
+
+    }
 
     /**
      * Creates a new instance.
+     * <p>
+     * This constructor has been deprecated. A context is no longer needed.
      *
      * @param applicationContext The application context. <b>Do not provide</b> a context wrapped by
      *                           {@link com.transifex.txnative.TxNative#wrap(Context) TxNative#wrap(Context)}
      *                           or {@link com.transifex.txnative.TxNative#generalWrap(Context) TxNative#generalWrap(Context)}.
      */
+    @Deprecated
     public AndroidMissingPolicy(@NonNull Context applicationContext) {
-        this.context = applicationContext;
     }
 
     /**
@@ -31,9 +40,10 @@ public class AndroidMissingPolicy implements MissingPolicy{
      * without using TxNative functionality.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
+    @NonNull public CharSequence get(@NonNull Resources resources,
+                                     @NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
-        return context.getResources().getText(id);
+        return resources.getText(id);
     }
 
     /**
@@ -43,9 +53,9 @@ public class AndroidMissingPolicy implements MissingPolicy{
      * without using TxNative functionality.
      */
     @Override
-    @NonNull public CharSequence getQuantityString(
+    @NonNull public CharSequence getQuantityString(@NonNull Resources resources,
             @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
             @NonNull String resourceName, @NonNull String locale) {
-        return context.getResources().getQuantityText(id, quantity);
+        return resources.getQuantityText(id, quantity);
     }
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicy.java
@@ -1,5 +1,7 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
@@ -29,11 +31,12 @@ public class CompositeMissingPolicy implements MissingPolicy{
      * Returns a string after it has been fed to all of the provided policies from first to last.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
+    @NonNull public CharSequence get(@NonNull Resources resources,
+                                     @NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         CharSequence string = sourceString;
         for (MissingPolicy policy : mMissingPolicies) {
-            string = policy.get(string, id, resourceName, locale);
+            string = policy.get(resources, string, id, resourceName, locale);
         }
 
         return  string;
@@ -44,12 +47,13 @@ public class CompositeMissingPolicy implements MissingPolicy{
      * to last.
      */
     @Override
-    @NonNull public CharSequence getQuantityString(
+    @NonNull public CharSequence getQuantityString(@NonNull Resources resources,
             @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
             @NonNull String resourceName, @NonNull String locale) {
         CharSequence quantityString = sourceQuantityString;
         for (MissingPolicy policy : mMissingPolicies) {
-            quantityString = policy.getQuantityString(quantityString, id, quantity, resourceName, locale);
+            quantityString = policy.getQuantityString(resources, quantityString, id, quantity,
+                    resourceName, locale);
         }
 
         return  quantityString;

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/MissingPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/MissingPolicy.java
@@ -3,6 +3,7 @@ package com.transifex.txnative.missingpolicy;
 import android.content.res.Resources;
 
 import com.transifex.txnative.LocaleState;
+import com.transifex.txnative.TxResources;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
@@ -20,6 +21,8 @@ public interface MissingPolicy {
      * Classes that implement this interface may choose to return anything relevant to the given
      * source string or not, based on their custom policy.
      *
+     * @param resources A Resources object. This is the wrapped resources object returned by
+     * {@link TxResources#getWrappedResources()}.
      * @param sourceString The source string.
      * @param id The string resource identifier as defined by
      * {@link Resources#getIdentifier(String, String, String)}.
@@ -29,8 +32,8 @@ public interface MissingPolicy {
      *
      * @return The translated string.
      */
-    @NonNull CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
-                              @NonNull String resourceName, @NonNull String locale);
+    @NonNull CharSequence get(@NonNull Resources resources, @NonNull CharSequence sourceString,
+                              @StringRes int id, @NonNull String resourceName, @NonNull String locale);
 
     /**
      * Return a quantity string as a translation based on the given source quantity string and
@@ -39,6 +42,8 @@ public interface MissingPolicy {
      * Classes that implement this interface may choose to return anything relevant to the given
      * source string or not, based on their custom policy.
      *
+     * @param resources A Resources object. This is the wrapped resources object returned by
+     * {@link TxResources#getWrappedResources()}.
      * @param sourceQuantityString The source string having grammatically correct pluralization for
      *                             the given quantity.
      * @param id The plurals resource identifier as defined by
@@ -51,7 +56,8 @@ public interface MissingPolicy {
      *
      * @return The translated string.
      */
-    @NonNull CharSequence getQuantityString(@NonNull CharSequence sourceQuantityString,
+    @NonNull CharSequence getQuantityString(@NonNull Resources resources,
+                                            @NonNull CharSequence sourceQuantityString,
                                             @PluralsRes int id, int quantity,
                                             @NonNull String resourceName, @NonNull String locale);
 }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicy.java
@@ -1,5 +1,7 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
+
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -149,8 +151,9 @@ public class PseudoTranslationPolicy implements MissingPolicy {
      * processed and will lose their markup.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
-                                      @NonNull String resourceName, @NonNull String locale) {
+    @NonNull public CharSequence get(@NonNull Resources resources,
+                                     @NonNull CharSequence sourceString, @StringRes int id,
+                                     @NonNull String resourceName, @NonNull String locale) {
         return processString(sourceString);
     }
 
@@ -161,7 +164,7 @@ public class PseudoTranslationPolicy implements MissingPolicy {
      * processed and will lose their markup.
      */
     @Override
-    @NonNull public CharSequence getQuantityString(
+    @NonNull public CharSequence getQuantityString(@NonNull Resources resources,
             @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
             @NonNull String resourceName, @NonNull String locale) {
         return processString(sourceQuantityString);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/SourceStringPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/SourceStringPolicy.java
@@ -1,5 +1,7 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
@@ -13,7 +15,8 @@ public class SourceStringPolicy implements MissingPolicy {
      * Return the source string as the translation string.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
+    @NonNull public CharSequence get(@NonNull Resources resources,
+                                     @NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         return sourceString;
     }
@@ -22,7 +25,7 @@ public class SourceStringPolicy implements MissingPolicy {
      * Returns the source quantity string as the translation quantity string.
      */
     @Override
-    @NonNull public CharSequence getQuantityString(
+    @NonNull public CharSequence getQuantityString(@NonNull Resources resources,
             @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
             @NonNull String resourceName, @NonNull String locale) {
         return sourceQuantityString;

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/missingpolicy/WrappedStringPolicy.java
@@ -1,6 +1,7 @@
 package com.transifex.txnative.missingpolicy;
 
 
+import android.content.res.Resources;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.SpannedString;
@@ -88,7 +89,8 @@ public class WrappedStringPolicy implements MissingPolicy{
      * Returns a wrapped string.
      */
     @Override
-    @NonNull public CharSequence get(@NonNull CharSequence sourceString, @StringRes int id,
+    @NonNull public CharSequence get(@NonNull Resources resources,
+                                     @NonNull CharSequence sourceString, @StringRes int id,
                                      @NonNull String resourceName, @NonNull String locale) {
         return wrapString(sourceString);
     }
@@ -97,7 +99,7 @@ public class WrappedStringPolicy implements MissingPolicy{
      * Returns a wrapped quantity string.
      */
     @Override
-    @NonNull public CharSequence getQuantityString(
+    @NonNull public CharSequence getQuantityString(@NonNull Resources resources,
             @NonNull CharSequence sourceQuantityString, @PluralsRes int id, int quantity,
             @NonNull String resourceName, @NonNull String locale) {
         return wrapString(sourceQuantityString);

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/AndroidMissingPolicyTest.java
@@ -42,8 +42,8 @@ public class AndroidMissingPolicyTest {
         CharSequence sourceString = "dummy source string";
         String resourceEntryName = mockContext.getResources().getResourceEntryName(R.string.tx_test_key);
 
-        AndroidMissingPolicy policy = new AndroidMissingPolicy(mockContext);
-        CharSequence translated = policy.get(sourceString, R.string.tx_test_key, resourceEntryName, "el");
+        AndroidMissingPolicy policy = new AndroidMissingPolicy();
+        CharSequence translated = policy.get(mockContext.getResources(), sourceString, R.string.tx_test_key, resourceEntryName, "el");
 
         assertThat(translated).isEqualTo("test ελ");
     }
@@ -57,8 +57,8 @@ public class AndroidMissingPolicyTest {
         CharSequence sourceString = "dummy source string";
         String resourceEntryName = mockContext.getResources().getResourceEntryName(R.plurals.tx_plural_test_key);
 
-        AndroidMissingPolicy policy = new AndroidMissingPolicy(mockContext);
-        CharSequence translated = policy.getQuantityString(sourceString, R.plurals.tx_plural_test_key, 1, resourceEntryName, "el");
+        AndroidMissingPolicy policy = new AndroidMissingPolicy();
+        CharSequence translated = policy.getQuantityString(mockContext.getResources(), sourceString, R.plurals.tx_plural_test_key, 1, resourceEntryName, "el");
 
         assertThat(translated).isEqualTo("αυτοκίνητο");
     }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/CompositeMissingPolicyTest.java
@@ -1,5 +1,9 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.Context;
+import android.content.res.Resources;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -8,7 +12,10 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
@@ -21,41 +28,48 @@ public class CompositeMissingPolicyTest {
     final String stringResourceName = "dummy_name";
     final String locale = "el";
 
+    private Resources resources;
+
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() {
+        resources = mock(Resources.class);
+    }
 
     @Test
     public void testGet_normal() {
         // Mock a missing policy that returns sourceString + " end"
         // and a missing policy that returns "start " + sourceString + " end2"
         MissingPolicy missingPolicy1 = mock(MissingPolicy.class);
-        when(missingPolicy1.get(anyString(), anyInt(), anyString(), anyString()))
+        when(missingPolicy1.get(any(), anyString(), anyInt(), anyString(), anyString()))
                 .thenAnswer(new Answer<String>() {
                     @Override
                     public String answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return args[0] + " end";
+                        return args[1] + " end";
                     }
         });
         MissingPolicy missingPolicy2 = mock(MissingPolicy.class);
-        when(missingPolicy2.get(anyString(), anyInt(), anyString(), anyString()))
+        when(missingPolicy2.get(any(), anyString(), anyInt(), anyString(), anyString()))
                 .thenAnswer(new Answer<String>() {
                     @Override
                     public String answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return "start " + args[0] + " end2";
+                        return "start " + args[1] + " end2";
             }
         });
 
         MissingPolicy[] missingPolicies = new MissingPolicy[]{missingPolicy1, missingPolicy2};
         CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(missingPolicies);
-        String result = compositeMissingPolicy.get("test", stringId, stringResourceName, locale).toString();
+        String result = compositeMissingPolicy.get(resources, "test", stringId, stringResourceName, locale).toString();
 
         // Verify that the get() methods of the missing policies were called in order and had the
         // expected arguments
         InOrder inOrder = inOrder(missingPolicy1, missingPolicy2);
-        inOrder.verify(missingPolicy1).get("test", stringId, stringResourceName, locale);
-        inOrder.verify(missingPolicy2).get("test end", stringId, stringResourceName, locale);
+        inOrder.verify(missingPolicy1).get(resources, "test", stringId, stringResourceName, locale);
+        inOrder.verify(missingPolicy2).get(resources, "test end", stringId, stringResourceName, locale);
         inOrder.verifyNoMoreInteractions();
         // Assert final result
         assertThat(result).isEqualTo("start test end end2");
@@ -64,7 +78,7 @@ public class CompositeMissingPolicyTest {
     @Test
     public void testGet_emptyPolicyArray_returnSourceString() {
         CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(new MissingPolicy[]{});
-        String result = compositeMissingPolicy.get("test", stringId, stringResourceName, locale).toString();
+        String result = compositeMissingPolicy.get(resources, "test", stringId, stringResourceName, locale).toString();
 
         assertThat(result).isEqualTo("test");
     }
@@ -74,33 +88,33 @@ public class CompositeMissingPolicyTest {
         // Mock a missing policy that returns sourceString + " end"
         // and a missing policy that returns "start " + sourceString + " end2"
         MissingPolicy missingPolicy1 = mock(MissingPolicy.class);
-        when(missingPolicy1.getQuantityString(anyString(), anyInt(), anyInt(), anyString(), anyString()))
+        when(missingPolicy1.getQuantityString(any(), anyString(), anyInt(), anyInt(), anyString(), anyString()))
                 .thenAnswer(new Answer<String>() {
                     @Override
                     public String answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return args[0] + " end";
+                        return args[1] + " end";
                     }
                 });
         MissingPolicy missingPolicy2 = mock(MissingPolicy.class);
-        when(missingPolicy2.getQuantityString(anyString(), anyInt(), anyInt(), anyString(), anyString()))
+        when(missingPolicy2.getQuantityString(any(), anyString(), anyInt(), anyInt(), anyString(), anyString()))
                 .thenAnswer(new Answer<String>() {
                     @Override
                     public String answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return "start " + args[0] + " end2";
+                        return "start " + args[1] + " end2";
                     }
                 });
 
         MissingPolicy[] missingPolicies = new MissingPolicy[]{missingPolicy1, missingPolicy2};
         CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(missingPolicies);
-        String result = compositeMissingPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale).toString();
+        String result = compositeMissingPolicy.getQuantityString(resources, "test", stringId, 1, stringResourceName, locale).toString();
 
         // Verify that the get() methods of the missing policies were called in order and had the
         // expected arguments
         InOrder inOrder = inOrder(missingPolicy1, missingPolicy2);
-        inOrder.verify(missingPolicy1).getQuantityString("test", stringId, 1, stringResourceName, locale);
-        inOrder.verify(missingPolicy2).getQuantityString("test end", stringId, 1, stringResourceName, locale);
+        inOrder.verify(missingPolicy1).getQuantityString(resources, "test", stringId, 1, stringResourceName, locale);
+        inOrder.verify(missingPolicy2).getQuantityString(resources, "test end", stringId, 1, stringResourceName, locale);
         inOrder.verifyNoMoreInteractions();
         // Assert final result
         assertThat(result).isEqualTo("start test end end2");
@@ -110,7 +124,7 @@ public class CompositeMissingPolicyTest {
     @Test
     public void testGetQuantityString_emptyPolicyArray_returnSourceString() {
         CompositeMissingPolicy compositeMissingPolicy = new CompositeMissingPolicy(new MissingPolicy[]{});
-        String result = compositeMissingPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale).toString();
+        String result = compositeMissingPolicy.getQuantityString(resources, "test", stringId, 1, stringResourceName, locale).toString();
 
         assertThat(result).isEqualTo("test");
     }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/PseudoTranslationPolicyTest.java
@@ -1,14 +1,25 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class PseudoTranslationPolicyTest {
 
     final int stringId = 0;
     final String stringResourceName = "dummy_name";
     final String locale = "el";
+
+    private Resources resources;
+
+    @Before
+    public void setUp() {
+        resources = mock(Resources.class);
+    }
 
     @Test
     public void testProcessString() {
@@ -60,7 +71,7 @@ public class PseudoTranslationPolicyTest {
     public void testGet() {
         String sourceString = "The quick\n brown fox \nένα!";
         PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.get(resources, sourceString, stringId, stringResourceName, locale);
 
         assertThat(translated).isEqualTo("Ťȟê ʠüıċǩ\n ƀȓøẁñ ƒøẋ \nένα!");
     }
@@ -69,7 +80,7 @@ public class PseudoTranslationPolicyTest {
     public void testGetQuantityString() {
         String sourceString = "The quick\n brown fox \nένα!";
         PseudoTranslationPolicy policy = new PseudoTranslationPolicy();
-        CharSequence translated = policy.getQuantityString(sourceString, stringId, 1, stringResourceName, locale);
+        CharSequence translated = policy.getQuantityString(resources, sourceString, stringId, 1, stringResourceName, locale);
 
         assertThat(translated).isEqualTo("Ťȟê ʠüıċǩ\n ƀȓøẁñ ƒøẋ \nένα!");
     }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/SourceStringPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/SourceStringPolicyTest.java
@@ -1,20 +1,30 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SourceStringPolicyTest {
 
     final int stringId = 0;
     final String stringResourceName = "dummy_name";
     final String locale = "el";
+    private Resources resources;
+
+    @Before
+    public void setUp() {
+        resources = mock(Resources.class);
+    }
 
     @Test
     public void testGet() {
         SourceStringPolicy sourceStringPolicy = new SourceStringPolicy();
 
-        assertThat(sourceStringPolicy.get("test", stringId, stringResourceName, locale))
+        assertThat(sourceStringPolicy.get(resources, "test", stringId, stringResourceName, locale))
                 .isEqualTo("test");
     }
 
@@ -22,7 +32,7 @@ public class SourceStringPolicyTest {
     public void testGetQuantityString() {
         SourceStringPolicy sourceStringPolicy = new SourceStringPolicy();
 
-        assertThat(sourceStringPolicy.getQuantityString("test", stringId, 1, stringResourceName, locale))
+        assertThat(sourceStringPolicy.getQuantityString(resources, "test", stringId, 1, stringResourceName, locale))
                 .isEqualTo("test");
     }
 }

--- a/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
+++ b/TransifexNativeSDK/txsdk/src/test/java/com/transifex/txnative/missingpolicy/WrappedStringPolicyTest.java
@@ -1,5 +1,6 @@
 package com.transifex.txnative.missingpolicy;
 
+import android.content.res.Resources;
 import android.os.Build;
 import android.text.Spanned;
 import android.text.SpannedString;
@@ -7,6 +8,7 @@ import android.text.style.StyleSpan;
 
 import com.transifex.txnative.Utils;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -14,6 +16,7 @@ import org.robolectric.annotation.Config;
 
 import static android.text.Html.FROM_HTML_MODE_LEGACY;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
@@ -22,6 +25,13 @@ public class WrappedStringPolicyTest {
     final int stringId = 0;
     final String stringResourceName = "dummy_name";
     final String locale = "el";
+
+    private Resources resources;
+
+    @Before
+    public void setUp() {
+        resources = mock(Resources.class);
+    }
 
     @Test
     public void testWrapString_normal() {
@@ -94,7 +104,7 @@ public class WrappedStringPolicyTest {
     public void testGet_normal() {
         WrappedStringPolicy policy = new WrappedStringPolicy("<", " !end");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.get(sourceString, stringId, stringResourceName, locale);
+        CharSequence translated = policy.get(resources, sourceString, stringId, stringResourceName, locale);
 
         assertThat(translated).isEqualTo("<The quick\n brown fox !end");
     }
@@ -103,7 +113,7 @@ public class WrappedStringPolicyTest {
     public void testGetQuantityString_normal() {
         WrappedStringPolicy policy = new WrappedStringPolicy("<", " !end");
         String sourceString = "The quick\n brown fox";
-        CharSequence translated = policy.getQuantityString(sourceString, stringId, 1, stringResourceName, locale);
+        CharSequence translated = policy.getQuantityString(resources, sourceString, stringId, 1, stringResourceName, locale);
 
         assertThat(translated).isEqualTo("<The quick\n brown fox !end");
     }


### PR DESCRIPTION
Previously, AndroidMissingPolicy was initialized with a context, whose resources were used for getting a translated string.

Using the same context for all calls can have negative side-effects. For example, if  the resources configurations is changed inside an activity for forcing a locale, the context used in AndroidMissingPolicy will not be affected.

This is why we no longer provide a context for constructing AndroidMissingPolicy. The original constructor has been deprecated but not removed. The provided context is ignored.

The MissingPolicy interface was updated so that all methods provide a Resources object.

The AndroidMissingPolicy uses the provided Resources object to retrieve translated strings.

NativeCore passes the wrapped resources object to the missing policy. We don't want to pass TxResources because calling an overriden method would result in a recursive loop.

All classes and unit tests have been updated.

The material library has been updated to 1.7.0.

Readme was updated.