### PR TITLE
Re-enable Kotlin

### DIFF
--- a/TransifexNativeSDK/build.gradle
+++ b/TransifexNativeSDK/build.gradle
@@ -35,6 +35,7 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
     id 'com.android.application' version '8.1.0' apply false
     id 'com.android.library' version '8.1.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
 }
 
 // Initialize publishing/signing extra properties with environmental vars

--- a/TransifexNativeSDK/txsdk/build.gradle
+++ b/TransifexNativeSDK/txsdk/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
@@ -28,6 +29,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 
     // https://developer.android.com/studio/publish-library/configure-pub-variants


### PR DESCRIPTION
Kotlin plugin and kotlin-stdlib were removed from the txsdk module in 11c91d22b1ec0f477687ee3573b9f2da66d5b5fb

The removal of the plugin resulted in kotlin files not being compiled and bundled in the final library. The only kotlin file that the project has and was affected, was: `TxContextWrappingDelegate`

Now, this class will be available to library users to use it if they want.