### PR TITLE
Add support for non-BMP Unicode characters in the CLI tool

### DIFF
--- a/TransifexNativeSDK/clitool/build.gradle
+++ b/TransifexNativeSDK/clitool/build.gradle
@@ -45,7 +45,7 @@ tasks.withType(Test).configureEach {
 
 dependencies {
     compileOnly "androidx.annotation:annotation:$versions.androidXAnnotation"
-    implementation 'org.jdom:jdom2:2.0.6'
+    implementation 'org.jdom:jdom2:2.0.6.1'
     implementation 'info.picocli:picocli:4.7.5'
     implementation project(':common')
 

--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
@@ -41,6 +41,11 @@ class StringXMLConverter {
     public StringXMLConverter() {
         mXmlOutputter = new XMLOutputter();
         Format format = Format.getRawFormat();
+        // https://stackoverflow.com/questions/54920849/converting-xml-not-work-utf-8-xmloutputter-java
+        // The default escape strategy escapes long unicode characters (non-BMP UTF-16 surrogate pairs)
+        // to Numeric character references: "&#xhhhh;" .
+        // We want to keep them as unicode.
+        format.setEscapeStrategy(ch -> false);
 
         format.setLineSeparator(LineSeparator.UNIX);
 

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
@@ -291,10 +291,13 @@ public class StringXMLConverterTest {
             e.printStackTrace();
         }
 
-        assertThat(stringMap.keySet()).containsExactly("key1", "key2", "key3").inOrder();
+        assertThat(stringMap.keySet()).containsExactly("key1", "key2", "key3", "key4", "key5", "key6").inOrder();
         assertThat(stringMap.get("key1").string).isEqualTo("Ελληνικά!");
         assertThat(stringMap.get("key2").string).isEqualTo("unicode heart: ❤");
         assertThat(stringMap.get("key3").string).isEqualTo("escaped heart: ❤");
+        assertThat(stringMap.get("key4").string).isEqualTo("html decimal escaped heart: ❤");
+        assertThat(stringMap.get("key5").string).isEqualTo("html hexadecimal escaped heart: ❤");
+        assertThat(stringMap.get("key6").string).isEqualTo("long unicode emoji: \uD83E\uDDD1\u200D\uD83E\uDD1D\u200D\uD83E\uDDD1");
     }
 
     @Test

--- a/TransifexNativeSDK/clitool/testFiles/strings-test-unicode.xml
+++ b/TransifexNativeSDK/clitool/testFiles/strings-test-unicode.xml
@@ -3,4 +3,7 @@
     <string name="key1">Ελληνικά!</string>
     <string name="key2">unicode heart: ❤</string>
     <string name="key3">escaped heart: \u2764</string>
+    <string name="key4">html decimal escaped heart: &#10084;</string>
+    <string name="key5">html hexadecimal escaped heart: &#x2764;</string>
+    <string name="key6">long unicode emoji: 🧑‍🤝‍🧑</string>
 </resources>


### PR DESCRIPTION
The CLI tool parses `strings.xml` so that they are uploaded to CDS. Even though it already supported Unicode characters, it didn't support non-BMP UTF-16 surrogate pairs (which are used by some emojis). Previously, such characters were converted to Numeric character references, in the form of &#xhhhh, which was not useful.

Now, they are kept (and pushed) in the original Unicode form.