### PR TITLE
Improve handling of "@"

### DIFF
--- a/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
+++ b/TransifexNativeSDK/clitool/src/main/java/com/transifex/clitool/StringXMLConverter.java
@@ -105,11 +105,14 @@ class StringXMLConverter {
 
             if (child.getName().equals("string")) {
                 String key = child.getAttribute("name").getValue();
-                String string = getXMLText(child);
+                String xmlText = getXMLText(child);
                 // Ignore resource references
-                if (string.startsWith("@")) {
+                if (xmlText.startsWith("@")) {
                     continue;
                 }
+                // Unescape special chars. For example convert a typed "\n" ("\\n" in Java) to a new line
+                // ("\n" in Java) and do some extra processing similar to the Android XML parser.
+                String string = unescapeJavaString(xmlText);
                 stringMap.put(key, new LocaleData.StringInfo(string));
             }
             else if (child.getName().equals("plurals")) {
@@ -145,13 +148,7 @@ class StringXMLConverter {
     }
 
     /**
-     * Returns the content of the provided element as text, including any XML content. It also
-     * applies the special character handling of Android's XML parser as defined
-     * <a href="https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes">here</a>.
-     * <p>
-     * The final processing of HTML entities and tags is left for the SDK at runtime. So, any tags
-     * are left as is. HTML entities such as {@code "&amp;", "&lt;" and "&gt;"}
-     * (with the exception of {@code "&quot;" which is converted to """} are left untouched.
+     * Returns the content of the provided element as text, including any XML content.
      */
     @NonNull
     private String getXMLText(@NonNull Element element) {
@@ -163,26 +160,21 @@ class StringXMLConverter {
             return "";
         }
 
-        String originalString = stringWriter.toString();
-
-        // We follow Android XML Parser's special character handling.
-
-        // Replace tabs with spaces.
-        String unescapedString = originalString.replace('\t', ' ');
-        // Unescape special chars. For example convert a typed "\n" ("\\n" in Java) to a new line
-        // ("\n" in Java) and do some extra processing similar to the Android XML parser.
-        unescapedString= unescapeJavaString(unescapedString);
-
-        return unescapedString;
+        return stringWriter.toString();
     }
 
     /**
      * Unescapes a string that contains standard Java escape sequences.
+     * <p>
+     * It also applies the special character handling of Android's XML parser as defined
+     * <a href="https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes">here</a>.
+     * <p>
+     * The final processing of HTML entities and tags is left for the SDK at runtime. So, any tags
+     * are left as is. HTML entities such as {@code "&amp;", "&lt;" and "&gt;"}
+     * (with the exception of {@code "&quot;" which is converted to """} are left untouched.
      * <ul>
      * <li><strong>&#92;b &#92;f &#92;n &#92;r &#92;t &#92;" &#92;'</strong> :
      * BS, FF, NL, CR, TAB, double and single quote.</li>
-     * <li><strong>&#92;X &#92;XX &#92;XXX</strong> : Octal character
-     * specification (0 - 377, 0x00 - 0xFF).</li>
      * <li><strong>&#92;uXXXX</strong> : Hexadecimal based Unicode character.</li>
      * </ul>
      *
@@ -190,10 +182,12 @@ class StringXMLConverter {
      *     original code</a> to follow the Android XML Parser behavior. Octal support has been
      *     removed. The following are now supported:
      *     <ul>
-     *         <li>Whitespace character sequences are collapsed into a single space, unless they
-     *         are enclosed in double quotes.</li>
+     *         <li>Tabs are converted to spaces.</li>
      *         <li>New lines are converted and collapsed into a single space, unless they are
      *         enclosed in double quotes.</li>
+     *         <li>Whitespace character sequences, either typed as such or converted from tabs or
+     *         new lines, are collapsed into a single space, unless they are enclosed in double
+     *         quotes.</li>
      *         <li>Double quotes are removed, unless escaped.</li>
      *         <li>Single quotes are removed (you can't actually write them using Android Studio's
      *         string editor), unless escaped or quoted.</li>
@@ -209,6 +203,8 @@ class StringXMLConverter {
      * @return The unescaped string.
      */
     public String unescapeJavaString(String st) {
+        // Replace tabs with spaces.
+        st = st.replace('\t', ' ');
 
         StringBuilder sb = new StringBuilder(st.length());
 

--- a/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
+++ b/TransifexNativeSDK/clitool/src/test/java/com/transifex/clitool/StringXMLConverterTest.java
@@ -144,6 +144,11 @@ public class StringXMLConverterTest {
         return getXMlFromFile("strings-test-htmlentities.xml");
     }
 
+    static Document getXMLAt() {
+
+        return getXMlFromFile("strings-test-at.xml");
+    }
+
     static Document getPluralsXML() {
         return getXML(stringsXMLPlurals);
     }
@@ -350,6 +355,22 @@ public class StringXMLConverterTest {
 
         assertThat(stringMap.keySet()).containsExactly("key1").inOrder();
         assertThat(stringMap.get("key1").string).isEqualTo("these html entities &amp; &lt; &gt; should be left as is");
+    }
+
+    @Test
+    public void testProcess_at() {
+        Document document = getXMLAt();
+        try {
+            converter.process(document, stringMap);
+        } catch (JDOMException | StringXMLConverter.XMLConverterException e) {
+            e.printStackTrace();
+        }
+
+        // key 2 should be ignored by our parser
+        assertThat(stringMap.keySet()).containsExactly("key1", "key3", "key4").inOrder();
+        assertThat(stringMap.get("key1").string).isEqualTo("using it here @ or escaped @ is ok");
+        assertThat(stringMap.get("key3").string).isEqualTo("@ this is ok");
+        assertThat(stringMap.get("key4").string).isEqualTo("<b>@</b> this is ok");
     }
 
     // endregion parse strings

--- a/TransifexNativeSDK/clitool/testFiles/strings-test-at.xml
+++ b/TransifexNativeSDK/clitool/testFiles/strings-test-at.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="key1">using it here @ or escaped \@ is ok</string>
+	<string name="key2">@resource this should be ignored</string>
+	<string name="key3">\@ this is ok</string>
+	<string name="key4"><b>@</b> this is ok</string>
+</resources>


### PR DESCRIPTION
We want to ignore strings that reference other strings.

However, our previous rules did not allow for some legitimate usage of the "@" or escaped "\@" character.

This is now improved.

To improve the checks, the xml text prion the un-escaping had to be exposed. This resulted to a small refactoring.