### PR TITLE
Wrap application context

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,43 @@ Context wrappedContext = TxNative.wrap(getApplicationContext());
 wrappedContext.getString();
 ```
 
+If you want to wrap the application context itself, you need to move the SDK's initialization from the application's `onCreate()` to `attachBaseContext()`:
+
+```java
+ @Override
+ protected void attachBaseContext(Context base) {
+    // Initialize TxNative
+    String token = "<transifex_token>";
+
+    LocaleState localeState = new LocaleState(
+        base,   // Use the base context instead of getApplicationContext()
+        // source locale
+        "en",
+        // supported locales
+        new String[]{"en", "el", "de", "fr", "ar", "sl", "es_ES", "es_MX"},
+        null);
+
+    TxNative.init(
+        // application context
+        base,   // Use the base context instead of getApplicationContext()
+        // a LocaleState instance
+        localeState,
+        // token
+        token,
+        // cdsHost URL
+        null,
+        // a TxCache implementation
+        null,
+        // a MissingPolicy implementation
+        new AndroidMissingPolicy());
+        
+        // Wrap the base application context
+        super.attachBaseContext(TxNative.wrap(base));
+}
+```
+
+Note though that this global wrapper can interfere with third-party libraries that use their own string resources. In that case, use "AndroidMissingPolicy" so that these libraries have their strings translated.
+
 If you want to disable the SDK functionality, don't initialize it and don't call any `TxNative` methods. `TxNative.wrap()` will be a no-op and the context will not be wrapped. Thus, all `getString()` etc methods, won't flow through the SDK.
 
 ## Cache

--- a/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/SimpleIntentService.java
+++ b/TransifexNativeSDK/app/src/main/java/com/transifex/myapplication/SimpleIntentService.java
@@ -24,8 +24,8 @@ public class SimpleIntentService extends JobIntentService {
 
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
-        // Make sure that you use getBaseContext() and not getApplicationContext()
-        String success = getBaseContext().getResources().getString(R.string.success);
+        // Make sure that you do not use an app context via getApplicationContext().getString()
+        String success = getString(R.string.success);
 
         Log.d(TAG, "Service status: " + success);
     }

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/NativeCore.java
@@ -65,7 +65,7 @@ public class NativeCore {
                       @Nullable String cdsHost,
                       @Nullable TxCache cache,
                       @Nullable MissingPolicy missingPolicy) {
-        mContext = applicationContext.getApplicationContext();
+        mContext = applicationContext;
         mMainHandler = new Handler(mContext.getMainLooper());
         mLocaleState = localeState;
         mLocaleState.setCurrentLocaleListener(mCurrentLocaleListener);

--- a/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
+++ b/TransifexNativeSDK/txsdk/src/main/java/com/transifex/txnative/TxNative.java
@@ -29,9 +29,10 @@ public class TxNative {
     private static NativeCore sNativeCore = null;
 
     /**
-     * Initialize the SDK.
+     * Initialize the SDK. The method should only be called once.
      * <p>
-     *     Should be called in {@link Application#onCreate()}.
+     *     Should be called in {@link Application#onCreate()} or
+     *     {@link Application#attachBaseContext(Context)}.
      * </p>
      *
      * @param applicationContext The application context.
@@ -61,6 +62,16 @@ public class TxNative {
 
         // Initialize ViewPump with our interceptor
         ViewPump.init(new TxInterceptor());
+    }
+
+    /**
+     * Checks if the SDK has been initialized by a previous call to
+     * {@link #init(Context, LocaleState, String, String, TxCache, MissingPolicy)}.
+     *
+     * @return <code>true</code> if the SDK has been initialized, <code>false</code> otherwise.
+     */
+    public static boolean isInitialized() {
+        return sNativeCore != null;
     }
 
     /**
@@ -158,9 +169,8 @@ public class TxNative {
      * <p>
      *   <b>Warning: </b>You should use <code>getBaseContext()</code>, instead of
      *      <code>getApplicationContext()</code> when using string methods in services.
-
      *
-     * @param context The activity context to wrap.
+     * @param context The context to wrap.
      *
      * @return The wrapped context.
      */
@@ -181,15 +191,9 @@ public class TxNative {
     /**
      * Wraps a context to enable TransifexNative functionality in services and other scopes besides
      * activities.
-     * <p>
-     * <b>Warning: </b>You should use <code>getBaseContext()</code>, instead of
-     * <code>getApplicationContext()</code> when using string methods in services.
-     * <p>
-     * Check out the installation guide regarding the usage of this method.
-     *
-     * @param context The service context to wrap.
      *
      * @return The wrapped context.
+     * @deprecated Use {@link #wrap(Context)} instead.
      */
     @Deprecated
     public static Context generalWrap(@NonNull Context context) {
@@ -201,6 +205,9 @@ public class TxNative {
      * that extends {@link androidx.appcompat.app.AppCompatActivity}.
      * <p>
      * This method should be called in {@link AppCompatActivity#getDelegate()}.
+     * <p>
+     * If your activity is extending {@link com.transifex.txnative.activity.TxBaseAppCompatActivity TxBaseAppCompatActivity}
+     * you don't have to call this method.
      *
      * @param delegate The activity's AppCompatDelegate.
      * @param baseContext The activity's base context.


### PR DESCRIPTION
The SDK can now wrap the application context.

Sample app, readme and documentation have been updated. In the readme, we still propose to initialize the SDK in the `onCreate()` method.

Introduced: `TxNative#isInitialized()`